### PR TITLE
Mutate array and strings

### DIFF
--- a/lib/zeitwerk/inflector.rb
+++ b/lib/zeitwerk/inflector.rb
@@ -12,7 +12,7 @@ module Zeitwerk
     # @param _abspath [String]
     # @return [String]
     def camelize(basename, _abspath)
-      basename.split('_').map(&:capitalize).join
+      basename.split('_').map!(&:capitalize!).join
     end
   end
 end


### PR DESCRIPTION
We can allocate a little bit less objects and gain 10%+ speedup ;) 

```ruby
Basename: api
ips benchmark:

Warming up --------------------------------------
            original    84.379k i/100ms
               patch    82.549k i/100ms
Calculating -------------------------------------
            original      1.142M (± 8.1%) i/s -      5.653M in   5.002194s
               patch      1.251M (± 3.6%) i/s -      6.274M in   5.022751s

Comparison:
               patch:  1250819.4 i/s
            original:  1141609.0 i/s - same-ish: difference falls within error


memory benchmark:

Calculating -------------------------------------
            original   368.000  memsize (     0.000  retained)
                         6.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
               patch   288.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
               patch:        288 allocated
            original:        368 allocated - 1.28x more

Basename: users_controller
ips benchmark:

Warming up --------------------------------------
            original    60.617k i/100ms
               patch    64.836k i/100ms
Calculating -------------------------------------
            original    726.944k (± 3.6%) i/s -      3.637M in   5.010178s
               patch    791.747k (± 3.0%) i/s -      4.020M in   5.082053s

Comparison:
               patch:   791746.7 i/s
            original:   726943.9 i/s - 1.09x  slower


memory benchmark:

Calculating -------------------------------------
            original   488.000  memsize (     0.000  retained)
                         9.000  objects (     0.000  retained)
                         5.000  strings (     0.000  retained)
               patch   368.000  memsize (     0.000  retained)
                         6.000  objects (     0.000  retained)
                         3.000  strings (     0.000  retained)

Comparison:
               patch:        368 allocated
            original:        488 allocated - 1.33x more

Basename: super_users_controller
ips benchmark:

Warming up --------------------------------------
            original    44.221k i/100ms
               patch    50.033k i/100ms
Calculating -------------------------------------
            original    549.705k (± 2.3%) i/s -      2.786M in   5.070776s
               patch    601.456k (± 2.4%) i/s -      3.052M in   5.077354s

Comparison:
               patch:   601456.3 i/s
            original:   549704.8 i/s - 1.09x  slower


memory benchmark:

Calculating -------------------------------------
            original   608.000  memsize (     0.000  retained)
                        12.000  objects (     0.000  retained)
                         7.000  strings (     0.000  retained)
               patch   448.000  memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)

Comparison:
               patch:        448 allocated
            original:        608 allocated - 1.36x more

Basename: very_super_users_controller
ips benchmark:

Warming up --------------------------------------
            original    32.404k i/100ms
               patch    37.308k i/100ms
Calculating -------------------------------------
            original    366.301k (± 2.2%) i/s -      1.847M in   5.044931s
               patch    415.391k (± 3.4%) i/s -      2.089M in   5.035547s

Comparison:
               patch:   415391.1 i/s
            original:   366301.1 i/s - 1.13x  slower


memory benchmark:

Calculating -------------------------------------
            original   920.000  memsize (     0.000  retained)
                        15.000  objects (     0.000  retained)
                         9.000  strings (     0.000  retained)
               patch   688.000  memsize (     0.000  retained)
                        10.000  objects (     0.000  retained)
                         5.000  strings (     0.000  retained)

Comparison:
               patch:        688 allocated
            original:        920 allocated - 1.34x more
```