### PR TITLE
Wrap assignments in conditional into parentheses

### DIFF
--- a/lib/zeitwerk/kernel.rb
+++ b/lib/zeitwerk/kernel.rb
@@ -11,7 +11,7 @@ module Kernel
   # @param path [String]
   # @return [Boolean]
   def require(path)
-    if loader = Zeitwerk::Registry.loader_for(path)
+    if (loader = Zeitwerk::Registry.loader_for(path))
       if path.end_with?(".rb")
         zeitwerk_original_require(path).tap do |required|
           loader.on_file_loaded(path) if required
@@ -23,7 +23,7 @@ module Kernel
       zeitwerk_original_require(path).tap do |required|
         if required
           realpath = $LOADED_FEATURES.last
-          if loader = Zeitwerk::Registry.loader_for(realpath)
+          if (loader = Zeitwerk::Registry.loader_for(realpath))
             loader.on_file_loaded(realpath)
           end
         end

--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -97,7 +97,7 @@ module Zeitwerk
 
       @tracer = TracePoint.trace(:class) do |tp|
         unless lazy_subdirs.empty? # do not even compute the hash key if not needed
-          if subdirs = lazy_subdirs.delete(tp.self.name)
+          if (subdirs = lazy_subdirs.delete(tp.self.name))
             subdirs.each { |subdir| set_autoloads_in_dir(subdir, tp.self) }
           end
         end
@@ -284,7 +284,7 @@ module Zeitwerk
       autovivified = parent.const_set(cname, Module.new)
       logger.call("module #{cpath(parent, cname)} autovivified from directory #{dir}") if logger
 
-      if subdirs = lazy_subdirs[cpath(parent, cname)]
+      if (subdirs = lazy_subdirs[cpath(parent, cname)])
         subdirs.each { |subdir| set_autoloads_in_dir(subdir, autovivified) }
       end
     end
@@ -343,7 +343,7 @@ module Zeitwerk
     # @param file [String]
     # @return [void]
     def autoload_file(parent, cname, file)
-      if autoload_path = autoload_for?(parent, cname)
+      if (autoload_path = autoload_for?(parent, cname))
         # First autoload for a Ruby file wins, just ignore subsequent ones.
         return if ruby?(autoload_path)
 

--- a/lib/zeitwerk/registry.rb
+++ b/lib/zeitwerk/registry.rb
@@ -117,7 +117,7 @@ module Zeitwerk
       # @param cpath [String]
       # @return [String, nil]
       def inception?(cpath)
-        if pair = inceptions[cpath]
+        if (pair = inceptions[cpath])
           pair.first
         end
       end


### PR DESCRIPTION
It's just safer to wrap assignments in conditionals into parentheses, so a developer won't mistake assignment operator with comparison operator.

https://github.com/rubocop-hq/ruby-style-guide#safe-assignment-in-condition