### PR TITLE
Improve speed and memory usage of Zeitwerk::Loader#actual_dirs

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -293,7 +293,7 @@ module Zeitwerk
 
     # @return [<String>]
     def actual_dirs
-      dirs.each_key.reject { |dir| ignored.member?(dir) }
+      dirs.keys.delete_if { |dir| ignored.member?(dir) }
     end
 
     # @param dir [String]


### PR DESCRIPTION
`{}.each_key.reject` creates 2 arrays.
`{}.keys.delete_if` creates 1 array.

1 item in `dirs` and 0 items in `ignored`:
```ruby
ips benchmark:

Warming up --------------------------------------
            original    91.571k i/100ms
               patch   201.972k i/100ms
Calculating -------------------------------------
            original      1.614M (± 7.0%) i/s -      8.058M in   5.018787s
               patch      4.342M (± 2.2%) i/s -     21.813M in   5.026412s

Comparison:
               patch:  4341870.6 i/s
            original:  1613954.0 i/s - 2.69x  slower


memory benchmark:

Calculating -------------------------------------
            original   168.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
               patch    40.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
               patch:         40 allocated
            original:        168 allocated - 4.20x more
```

1 item in `dirs` and 1 item in `ignored` (the same values):
```ruby
ips benchmark:

Warming up --------------------------------------
            original   126.046k i/100ms
               patch   230.406k i/100ms
Calculating -------------------------------------
            original      1.794M (± 6.5%) i/s -      8.949M in   5.020663s
               patch      4.555M (± 3.2%) i/s -     22.810M in   5.012927s

Comparison:
               patch:  4555373.5 i/s
            original:  1793797.0 i/s - 2.54x  slower


memory benchmark:

Calculating -------------------------------------
            original   168.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
               patch    40.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
               patch:         40 allocated
            original:        168 allocated - 4.20x more
```

26 items in `dirs` (`'a'..'z'`) and 0 items in `ignored`:
```ruby
ips benchmark:

Warming up --------------------------------------
            original    24.670k i/100ms
               patch    35.473k i/100ms
Calculating -------------------------------------
            original    274.062k (± 6.1%) i/s -      1.382M in   5.061159s
               patch    411.600k (± 3.8%) i/s -      2.057M in   5.006296s

Comparison:
               patch:   411599.9 i/s
            original:   274061.7 i/s - 1.50x  slower


memory benchmark:

Calculating -------------------------------------
            original   464.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
               patch   248.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
               patch:        248 allocated
            original:        464 allocated - 1.87x more
```

26 items in `dirs` (`'a'..'z'`) and 4 items in `ignored` (`["a", "c", "z", "j"]`):
```ruby
ips benchmark:

Warming up --------------------------------------
            original    24.941k i/100ms
               patch    30.721k i/100ms
Calculating -------------------------------------
            original    259.857k (±13.6%) i/s -      1.272M in   5.042758s
               patch    368.927k (± 2.4%) i/s -      1.874M in   5.082556s

Comparison:
               patch:   368927.2 i/s
            original:   259856.6 i/s - 1.42x  slower


memory benchmark:

Calculating -------------------------------------
            original   464.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
               patch   248.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
               patch:        248 allocated
            original:        464 allocated - 1.87x more
```