### PR TITLE
Allow to ignore paths with regular expression

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -156,7 +156,15 @@ module Zeitwerk
     # @param paths [<String, Pathname, <String, Pathname>>]
     # @return [void]
     def ignore(*paths)
-      mutex.synchronize { ignored.merge(expand_paths(paths)) }
+      paths.flatten.each do |path|
+        expanded_path = expand_paths(path)
+
+        if Dir[expanded_path.first].empty?
+          mutex.synchronize { ignored.merge(expanded_path) }
+        else
+          mutex.synchronize { ignored.merge(Dir[*expanded_path]) }
+        end
+      end
     end
 
     # Sets autoloads in the root namespace and preloads files, if any.

--- a/test/lib/zeitwerk/test_ignore.rb
+++ b/test/lib/zeitwerk/test_ignore.rb
@@ -68,20 +68,25 @@ class TestIgnore < LoaderTest
   test "ignored directories are not eager loaded" do
     files = [
       ["x.rb", "X = true"],
-      ["m/a.rb", "M::A = true"],
-      ["m/b.rb", "M::B = true"],
-      ["m/c.rb", "M::C = true"]
+      ["a/s/a.rb", "A::S::A = true"],
+      ["b/n/z.rb", "B::N::Z = true"],
+      ["b/n/x.h", "B::N::X = true"],
+      ["b/n/s/b.rb", "B::N::S::B = true"],
+      ["c/c.rb", "C::C = true"]
     ]
 
     with_files(files) do
       loader.push_dir(".")
-      loader.ignore("m")
+      loader.ignore("**/s", "*.h")
       loader.setup
       loader.eager_load
 
-      assert_equal 1, loader.autoloads.size
+      assert_equal 7, loader.autoloads.size
       assert ::X
-      assert_raises(NameError) { ::M }
+      assert C::C
+      assert B::N::Z
+      assert_raises(NameError) { A::S::A }
+      assert_raises(NameError) { B::N::X }
     end
   end
 


### PR DESCRIPTION
Right now we need to exclude all files in a particular directory or
files with particular name we will need to pass a full list into an
ignore method. In order to simplify this workflow we could add ability
to ignore paths based on regular expression that Dir.glob can recognize.