### PR TITLE
Add Loader#do_preload_abspath to process single absolute paths

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -150,13 +150,7 @@ module Zeitwerk
       mutex.synchronize do
         expand_paths(paths).each do |abspath|
           preloads << abspath
-          if @setup
-            if ruby?(abspath)
-              do_preload_file(abspath)
-            elsif dir?(abspath)
-              do_preload_dir(abspath)
-            end
-          end
+          do_preload_abspath(abspath) if @setup
         end
       end
     end
@@ -352,7 +346,7 @@ module Zeitwerk
     end
 
     # @param parent [Module]
-    # @paran cname [String]
+    # @param cname [String]
     # @param subdir [String]
     # @return [void]
     def autoload_subdir(parent, cname, subdir)
@@ -374,7 +368,7 @@ module Zeitwerk
     end
 
     # @param parent [Module]
-    # @paran cname [String]
+    # @param cname [String]
     # @param file [String]
     # @return [void]
     def autoload_file(parent, cname, file)
@@ -449,11 +443,17 @@ module Zeitwerk
     # @return [void]
     def do_preload
       preloads.each do |abspath|
-        if ruby?(abspath)
-          do_preload_file(abspath)
-        elsif dir?(abspath)
-          do_preload_dir(abspath)
-        end
+        do_preload_abspath(abspath)
+      end
+    end
+
+    # @param abspath [String]
+    # @return [void]
+    def do_preload_abspath(abspath)
+      if ruby?(abspath)
+        do_preload_file(abspath)
+      elsif dir?(abspath)
+        do_preload_dir(abspath)
       end
     end
 
@@ -461,11 +461,7 @@ module Zeitwerk
     # @return [void]
     def do_preload_dir(dir)
       each_abspath(dir) do |abspath|
-        if ruby?(abspath)
-          do_preload_file(abspath)
-        elsif dir?(abspath)
-          do_preload_dir(abspath)
-        end
+        do_preload_abspath(abspath)
       end
     end
 


### PR DESCRIPTION
The logic for pre-loading a single path was spread in several methods. This patch tries to unify them into a single method that can be reused.

Feel free to ignore it if everything was done that way on purpose, I wasn't really sure if it made sense to factor this logic out.

PS. Your work on this loader is amazing, it makes it really easy to grasp such a core concept in Ruby.