### PR TITLE
Allow to specify an alternative namespace in push_dir

### DIFF
--- a/test/lib/zeitwerk/test_push_dir.rb
+++ b/test/lib/zeitwerk/test_push_dir.rb
@@ -4,13 +4,13 @@ require "pathname"
 class TesPushDir < LoaderTest
   test "accepts dirs as strings and stores their absolute paths" do
     loader.push_dir(".")
-    assert loader.root_dirs == { Dir.pwd => true }
+    assert loader.root_dirs == { Dir.pwd => Object }
     assert loader.dirs.include?(Dir.pwd)
   end
 
   test "accepts dirs as pathnames and stores their absolute paths" do
     loader.push_dir(Pathname.new("."))
-    assert loader.root_dirs == { Dir.pwd => true }
+    assert loader.root_dirs == { Dir.pwd => Object }
     assert loader.dirs.include?(Dir.pwd)
   end
 
@@ -18,5 +18,15 @@ class TesPushDir < LoaderTest
     dir = File.expand_path("non-existing")
     e = assert_raises(ArgumentError) { loader.push_dir(dir) }
     assert_equal "the root directory #{dir} does not exist", e.message
+  end
+
+  module MyApp
+  end
+
+  test "an alternative namespace can be passed" do
+    files = [["app/x.rb", "TesPushDir::MyApp::X = true"]]
+    with_setup(files, dirs: [['app', namespace: MyApp]]) do
+      assert MyApp::X
+    end
   end
 end

--- a/test/support/loader_test.rb
+++ b/test/support/loader_test.rb
@@ -44,7 +44,7 @@ class LoaderTest < Minitest::Test
 
   def with_setup(files, dirs: ".", load_path: nil, rm: true)
     with_files(files, rm: rm) do
-      Array(dirs).each { |dir| loader.push_dir(dir) }
+      Array(dirs).each { |dir| loader.push_dir(*Array(dir)) }
       loader.setup
       if load_path
         with_load_path(load_path) { yield }


### PR DESCRIPTION
Hi, first thanks for Zeitwerk.

For context I'm currently experimenting with integrating Zeitwerk in our [Lita](https://github.com/litaio/lita) based chat bot so that we can benefit from an autoloader in development.

And in our chat bot, the constant to file path convention is mostly respected except that the top level namespace is implicit. e.g. `AppName::Foo::Bar` is located in `app/foo/bar.rb` because everything is under that namespace anyway.

I can perfectly move files around, it's really not the end of the world, but looking at Zeitwerk's source it seemed very easy to support implicit namespace, so I decided to suggest the feature.

If you feel like this is unnecessary added complexity that's fine.

@fxn what do you think?

cc @etiennebarrie @rafaelfranca 