### PR TITLE
Handle a similar name being used both inside a class and it's parent

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -415,7 +415,15 @@ module Zeitwerk
     # @param cname [String]
     # @return [String, nil]
     def autoload_for?(parent, cname)
-      parent.autoload?(cname) || Registry.inception?(cpath(parent, cname))
+      if autoload_path = parent.autoload?(cname)
+        if parent.is_a?(Class)
+          autoload_path if parent.superclass.autoload?(cname) != autoload_path
+        else
+          autoload_path
+        end
+      else
+        Registry.inception?(cpath(parent, cname))
+      end
     end
 
     # This method is called this way because I prefer `preload` to be the method


### PR DESCRIPTION
Ok, so I stepped upon a weird corner case which is summed up in the included test case (that fails on master).

### What's going on here?

Took me a while to figure out, I tried reproducing the behavior in small snippets without success, until I noticed it's a behavior that is specific to classes and I was trying to repro with modules.

Small snippet to showcase that behavior:

```ruby
class Foo
  autoload :Eggspam, 'eggspam.rb'
end

class Bar < Foo
end

p Foo.autoload?(:Eggspam) # => 'eggspam.rb'
p Bar.autoload?(:Eggspam) # => 'eggspam.rb'
```

TL;DR; `autoload` directives are inherited from parent classes.

Because of this, having both `Bar` and `Foo::Bar` only works if `Foo` is a module and not a class, unless `Bar` is reference before `Foo::Bar`.

### Solution 

`autoload_for?` is being used to not register a new autoload if one is already set. In this PR I make it inheritance aware, if `parent.autoload?` matches something, we check `parent`'s superclass and return `nil` if it has the same autoload registered, because that indicates it was inherited.

cc @fxn @rafaelfranca @Edouard-chin