### PR TITLE
Add support for multiple loaders cooperating over the same namespace

### DIFF
--- a/lib/zeitwerk/loader/callbacks.rb
+++ b/lib/zeitwerk/loader/callbacks.rb
@@ -23,7 +23,7 @@ module Zeitwerk::Loader::Callbacks
     log("module #{autovivified_module.name} autovivified from directory #{dir}") if logger
 
     loaded.add(autovivified_module.name)
-    on_namespace_loaded(autovivified_module)
+    Zeitwerk::Registry.loaders.each { |l| l.on_namespace_loaded(autovivified_module) }
   end
 
   # Invoked when a class or module is created or reopened, either from the

--- a/test/lib/zeitwerk/test_multiple.rb
+++ b/test/lib/zeitwerk/test_multiple.rb
@@ -54,4 +54,66 @@ class TestMultiple < LoaderTest
       assert App1::Foo::Bar::Baz
     end
   end
+
+  test "multiple loaders sharing an autovivified namespace" do
+    loaders = [loader, Zeitwerk::Loader.new]
+
+    files = [
+      ["lib0/namespace/foo.rb", <<-EOS],
+        module Namespace
+          class Foo
+          end
+        end
+      EOS
+      ["lib1/namespace/bar.rb", <<-EOS]
+        module Namespace
+          class Bar
+          end
+        end
+      EOS
+    ]
+    with_files(files) do
+      loaders[0].push_dir("lib0")
+      loaders[1].push_dir("lib1")
+      loaders.each(&:setup)
+
+      assert ::Namespace
+      assert ::Namespace::Foo
+      assert ::Namespace::Bar
+    end
+  end
+
+  test "multiple loaders sharing an explicit namespace" do
+    loaders = [loader, Zeitwerk::Loader.new]
+
+    files = [
+      ["lib0/namespace.rb", <<-EOS],
+        module Namespace
+        end
+      EOS
+      ["lib0/namespace/foo.rb", <<-EOS],
+        module Namespace
+          class Foo
+          end
+        end
+      EOS
+      ["lib1/namespace/bar.rb", <<-EOS]
+        module Namespace
+          class Bar
+          end
+        end
+      EOS
+    ]
+    with_files(files) do
+      loaders[0].push_dir("lib0")
+      loaders[0].tag = 'lib0'
+      loaders[1].push_dir("lib1")
+      loaders[1].tag = 'lib1'
+      loaders.each(&:setup)
+
+      assert ::Namespace
+      assert ::Namespace::Foo
+      assert ::Namespace::Bar
+    end
+  end
 end

--- a/test/lib/zeitwerk/test_unload.rb
+++ b/test/lib/zeitwerk/test_unload.rb
@@ -91,16 +91,16 @@ class TestUnload < LoaderTest
       la = Zeitwerk::Loader.new
       la.push_dir("a")
       la.setup
-      assert Zeitwerk::ExplicitNamespace.cpaths["M"] == la
+      assert_includes Zeitwerk::ExplicitNamespace.cpaths["M"], la
 
       lb = Zeitwerk::Loader.new
       lb.push_dir("b")
       lb.setup
-      assert Zeitwerk::ExplicitNamespace.cpaths["X"] == lb
+      assert_includes Zeitwerk::ExplicitNamespace.cpaths["X"], lb
 
       la.unload
-      assert_nil Zeitwerk::ExplicitNamespace.cpaths["M"]
-      assert Zeitwerk::ExplicitNamespace.cpaths["X"] == lb
+      refute Zeitwerk::ExplicitNamespace.cpaths.key?("M")
+      assert_includes Zeitwerk::ExplicitNamespace.cpaths["X"], lb
     end
   end
 end


### PR DESCRIPTION
To begin, I understand that this use case has been deliberately rejected as mentioned in the README and in `ExplicitNamespace` comments. However I'd like to make a case for it.

### Why is it needed?

The Zeitwerk integration in Rails (that you wrote) use multiple loaders to handle different autoloading behavior. There's `Rails.autoloaders.main` for `config.eager_load_paths` and  `Rails.autoloaders.once` for `config.autoload_once_paths` (and I'm about to submit a PR to add two more).

Because of this the following scenario won't work:

```ruby
# config/application.rb
config.autoload_once_paths << root.join('lib')

# app/models/pricing.rb
class Pricing < AR::Base
end

# lib/pricing/calculator.rb
class Pricing::Calculator
end
```

What is happening here, is that `Rails.autoloader.once` will record `lib/pricing/` for it to be autovivified, but will never receive the `on_namespace_loaded` callback, hence won't register an `autoload` for `Calculator` after `Pricing` is loaded.

### Note on the implementation

Currently this patch calls `on_namespace_loaded` on all loaders when a directory is autoloaded, we could certainly optimize this by registering the loaders which need to be called.

But I'd rather validate the approach with you first.

cc @fxn @rafaelfranca @Edouard-chin