### PR TITLE
Bring back the do_not_eager_load feature

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -89,6 +89,10 @@ module Zeitwerk
     attr_reader :lazy_subdirs
 
     # @private
+    # @return [Set<String>]
+    attr_reader :eager_load_exclusions
+
+    # @private
     # @return [Mutex]
     attr_reader :mutex
 
@@ -99,13 +103,14 @@ module Zeitwerk
       @inflector = Inflector.new
       @logger    = self.class.default_logger
 
-      @root_dirs     = {}
-      @preloads      = []
-      @ignored       = Set.new
-      @ignored_paths = Set.new
-      @autoloads     = {}
-      @loaded        = Set.new
-      @lazy_subdirs  = {}
+      @root_dirs            = {}
+      @preloads             = []
+      @ignored              = Set.new
+      @ignored_paths        = Set.new
+      @autoloads            = {}
+      @loaded               = Set.new
+      @lazy_subdirs         = {}
+      @eager_load_exclusions = Set.new
 
       @mutex        = Mutex.new
       @setup        = false
@@ -238,16 +243,18 @@ module Zeitwerk
 
     # Eager loads all files in the root directories, recursively. Files do not
     # need to be in `$LOAD_PATH`, absolute file names are used. Ignored files
-    # are not eager loaded.
+    # are not eager loaded. You can opt-out specifically in specific files and
+    # directories with `do_not_eager_load`.
     #
     # @return [void]
     def eager_load
       mutex.synchronize do
         break if @eager_loaded
 
-        queue = non_ignored_root_dirs
+        queue = non_ignored_root_dirs.reject { |dir| eager_load_exclusions.member?(dir) }
         while dir = queue.shift
           each_abspath(dir) do |abspath|
+            next if eager_load_exclusions.member?(abspath)
             if ruby?(abspath)
               require abspath
             elsif dir?(abspath)
@@ -258,6 +265,15 @@ module Zeitwerk
 
         @eager_loaded = true
       end
+    end
+
+    # Let eager load ignore the given files or directories. The constants
+    # defined in those files are still autoloadable.
+    #
+    # @param paths [<String, Pathname, <String, Pathname>>]
+    # @return [void]
+    def do_not_eager_load(*paths)
+      mutex.synchronize { eager_load_exclusions.merge(expand_paths(paths)) }
     end
 
     # Says if the given constant path has been loaded.

--- a/test/lib/zeitwerk/test_eager_load.rb
+++ b/test/lib/zeitwerk/test_eager_load.rb
@@ -66,4 +66,52 @@ class TestEagerLoad < LoaderTest
       assert $tel1
     end
   end
+
+  test "we can opt-out of entire root directories, and still autoload" do
+    $test_eager_load_eager_loaded_p = false
+    files = [["foo.rb", "Foo = true; $test_eager_load_eager_loaded_p = true"]]
+    with_setup(files) do
+      loader.do_not_eager_load(".")
+      loader.eager_load
+
+      assert !$test_eager_load_eager_loaded_p
+      assert Foo
+    end
+  end
+
+  test "we can opt-out of sudirectories, and still autoload" do
+    $test_eager_load_eager_loaded_p = false
+    files = [
+      ["db_adapters/mysql_adapter.rb", <<-EOS],
+        module DbAdapters::MysqlAdapter
+        end
+        $test_eager_load_eager_loaded_p = true
+      EOS
+      ["foo.rb", "Foo = true"]
+    ]
+    with_setup(files) do
+      loader.do_not_eager_load("db_adapters")
+      loader.eager_load
+
+      assert Foo
+      assert !$test_eager_load_eager_loaded_p
+      assert DbAdapters::MysqlAdapter
+    end
+  end
+
+  test "we can opt-out of files, and still autoload" do
+    $test_eager_load_eager_loaded_p = false
+    files = [
+      ["foo.rb", "Foo = true"],
+      ["bar.rb", "Bar = true; $test_eager_load_eager_loaded_p = true"]
+    ]
+    with_setup(files) do
+      loader.do_not_eager_load("bar.rb")
+      loader.eager_load
+
+      assert Foo
+      assert !$test_eager_load_eager_loaded_p
+      assert Bar
+    end
+  end
 end


### PR DESCRIPTION
As discussed in https://github.com/fxn/zeitwerk/pull/20#issuecomment-472324682 I'm trying to bring back the possibility to have directories being autoloaded, but not eager loaded.

This is more or less a revert of https://github.com/fxn/zeitwerk/commit/a1bd83b10521f41f7f74e921602839a1813d11e4

I tested it with [this Rails patch](https://github.com/rails/rails/compare/master...Shopify:zeitwerk-autoload-paths-2) and it seems to work as expected.

@fxn would you be ok with bringing that feature back?

cc @rafaelfranca @Edouard-chin