### PR TITLE
Optimize the TracePoint callback

### DIFF
--- a/lib/zeitwerk/explicit_namespace.rb
+++ b/lib/zeitwerk/explicit_namespace.rb
@@ -57,9 +57,19 @@ module Zeitwerk
     @cpaths = {}
     @mutex  = Mutex.new
     @tracer = TracePoint.new(:class) do |event|
+      # If the class is a singleton class, we won't do anything with it so we can bail out immediately.
+      # This is several order of magnitude faster than accessing `Module#name`, so we do it first.
+      break if event.self.singleton_class?
+
+      # MRI allocates a new string every time Module#name is called, so we hold onto it to save an allocation.
+      name = event.self.name
+
+      # If the clas is anonymous, we won't do anyhing with it, so we can bail out here as well.
+      break unless name
+
       # Note that it makes sense to compute the hash code unconditionally,
       # because the trace point is disabled if cpaths is empty.
-      if loader = cpaths.delete(event.self.name)
+      if loader = cpaths.delete(name)
         loader.on_namespace_loaded(event.self)
         disable_tracer_if_unneeded
       end


### PR DESCRIPTION
### Context

While experimenting with Zeitwerk on an existing Rails app, one test became extremely slow (I'm not even sure how long it takes as it never completed, but I estimate it at over 15 minutes, from ~3s previously).

So I decided to profile that test (or rather a subset of what it's doing) and got this:

```
$ stackprof tmp/stackprof-stripe-wall-.dump 
==================================
  Mode: wall(1000)
  Samples: 6 (83.78% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
         5  (83.3%)           5  (83.3%)     block in <module:ExplicitNamespace>
         1  (16.7%)           1  (16.7%)     Set#each
         5  (83.3%)           0   (0.0%)     Stripe::StripeObject#metaclass
         1  (16.7%)           0   (0.0%)     Stripe::StripeObject#remove_accessors
         6 (100.0%)           0   (0.0%)     Stripe::StripeObject#initialize_from
         6 (100.0%)           0   (0.0%)     Stripe::StripeObject.construct_from
         6 (100.0%)           0   (0.0%)     block (2 levels) in <class:StripeParserTest>
         6 (100.0%)           0   (0.0%)     block in <class:StripeParserTest>
```

So basically what is happening is that the Stripe gem (but could be any other dependency really, I'm not particularly pointing fingers here) is defining methods on instances, which lazily creates singleton classes. 

These singleton classes are spamming the TracePoint callback so much that everything slows down to a crawl.

### The patch

I tried making the callback bail out as soon as possible when it's clear the class is not relevant to Zeitwerk (i.e. is a `singleton_class`).

Unfortunately it's still way too slow, so I'll have to figure something else, but I suppose an optimization is always good to take.

@fxn what do you think? Also if you have other ideas how to solve this issue I'm all ears.

cc @rafaelfranca @Edouard-chin