### PR TITLE
Add a test case for singleton classes in TracePoint, and fix next vs break

### DIFF
--- a/lib/zeitwerk/explicit_namespace.rb
+++ b/lib/zeitwerk/explicit_namespace.rb
@@ -59,13 +59,13 @@ module Zeitwerk
     @tracer = TracePoint.new(:class) do |event|
       # If the class is a singleton class, we won't do anything with it so we can bail out immediately.
       # This is several order of magnitude faster than accessing `Module#name`, so we do it first.
-      break if event.self.singleton_class?
+      next if event.self.singleton_class?
 
       # MRI allocates a new string every time Module#name is called, so we hold onto it to save an allocation.
       name = event.self.name
 
       # If the clas is anonymous, we won't do anyhing with it, so we can bail out here as well.
-      break unless name
+      next unless name
 
       # Note that it makes sense to compute the hash code unconditionally,
       # because the trace point is disabled if cpaths is empty.

--- a/test/lib/zeitwerk/test_explicit_namespace.rb
+++ b/test/lib/zeitwerk/test_explicit_namespace.rb
@@ -130,4 +130,18 @@ class TestExplicitNamespace < LoaderTest
       assert !tracer.enabled?
     end
   end
+
+  test "the tracer handle anonymous modules" do
+    files = [
+      ["hotel.rb", "class Hotel; class << self; def x; 1; end; end; end"],
+      ["hotel/pricing.rb", "class Hotel::Pricing; end"],
+      ["car.rb", "class Car; end"],
+      ["car/pricing.rb", "class Car::Pricing; end"],
+    ]
+
+    with_setup(files) do
+      assert tracer.enabled?
+      assert_equal 1, Hotel.x
+    end
+  end
 end


### PR DESCRIPTION
Followup to: https://github.com/fxn/zeitwerk/pull/24

Turns out we can't use break here, otherwise we get a `LocalJumpError: break from proc-closure` (which makes me wonder if we could have a callback without a closure, which perf wise could be interesting, but that's another story).

The test case to exercise this code path is a bit complicated, as need extra unloaded namespaces to ensure the loader stays enabled.

This only test singleton classes, I tried to generate a case for regular anonymous classes with `Class#new` and `Module#new`, but without success so far. I don't know why TracePoint doesn't trigger in these cases.

@fxn 

