### PR TITLE
Pass the parent cpath as second arguments for camelization

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ The inflectors that ship with Zeitwerk are deterministic and simple. But you can
 # frozen_string_literal: true
 
 class MyInflector < Zeitwerk::Inflector
-  def camelize(basename, _abspath)
+  def camelize(basename, _cpath, _abspath)
     case basename
     when "api"
       "API"
@@ -297,7 +297,9 @@ end
 
 The first argument, `basename`, is a string with the basename of the file or directory to be inflected. In the case of a file, without extension. The inflector needs to return this basename inflected. Therefore, a simple constant name without colons.
 
-The second argument, `abspath`, is a string with the absolute path to the file or directory in case you need it to decide how to inflect the basename.
+The second argument, `cpath`, is a string with the fully qualified name of the parent constant, e.g. `"SomeNanespace::SubNamespace"`.
+
+The third argument, `abspath`, is a string with the absolute path to the file or directory in case you need it to decide how to inflect the basename.
 
 Then, assign the inflector:
 
@@ -478,7 +480,7 @@ I'd like to thank [@matthewd](https://github.com/matthewd) for the discussions w
 
 Also, would like to thank [@Shopify](https://github.com/Shopify), [@rafaelfranca](https://github.com/rafaelfranca), and [@dylanahsmith](https://github.com/dylanahsmith), for sharing [this PoC](https://github.com/Shopify/autoload_reloader). The technique Zeitwerk uses to support explicit namespaces was copied from that project.
 
-Finally, many thanks to [@schurig](https://github.com/schurig) for recording an [audio file](http://share.hashref.com/zeitwerk/zeitwerk_pronunciation.mp3) with the pronunciation of "Zeitwerk" in perfect German. 💯
+Finally, many thanks to [@schurig](https://github.com/schurig) for recording an [audio file](http://share.hashref.com/zeitwerk/zeitwerk_pronunciation.mp3) with the pronunciation of "Zeitwerk" in perfect German. :100:
 
 ## License
 

--- a/lib/zeitwerk/gem_inflector.rb
+++ b/lib/zeitwerk/gem_inflector.rb
@@ -10,9 +10,10 @@ module Zeitwerk
     end
 
     # @param basename [String]
+    # @param _cpath [String]
     # @param abspath [String]
     # @return [String]
-    def camelize(basename, abspath)
+    def camelize(basename, _cpath, abspath)
       (basename == "version" && abspath == @version_file) ? "VERSION" : super
     end
   end

--- a/lib/zeitwerk/inflector.rb
+++ b/lib/zeitwerk/inflector.rb
@@ -9,9 +9,10 @@ module Zeitwerk
     #   Zeitwerk::Inflector.camelize("api", ...)              # => "Api"
     #
     # @param basename [String]
+    # @param _cpath [String]
     # @param _abspath [String]
     # @return [String]
-    def camelize(basename, _abspath)
+    def camelize(basename, _cpath, _abspath)
       basename.split('_').map!(&:capitalize!).join
     end
   end

--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -361,7 +361,8 @@ module Zeitwerk
     # @return [void]
     def set_autoloads_in_dir(dir, parent)
       each_abspath(dir) do |abspath|
-        cname = inflector.camelize(File.basename(abspath, ".rb"), abspath)
+        cpath = parent == Object ? nil : parent.name
+        cname = inflector.camelize(File.basename(abspath, ".rb"), cpath, abspath)
         if ruby?(abspath)
           autoload_file(parent, cname, abspath)
         elsif dir?(abspath)

--- a/test/lib/test_inflector.rb
+++ b/test/lib/test_inflector.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class TestInflector < Minitest::Test
   def camelize(str)
-    Zeitwerk::Inflector.new.camelize(str, nil)
+    Zeitwerk::Inflector.new.camelize(str, nil, nil)
   end
 
   test "capitalizes the first letter" do


### PR DESCRIPTION
### Why ?

I've encountered a few cases where the same path segment is camelized in different ways in different namespaces (I know...). e.g. `Foo::API` and `Bar::Api`.

It's bad, and ultimately I'd like to clean it up, but I think Zeitwerk should make it easy to handle.

Right now it's possible by matching the path, but it's not as convenient as matching the constant path because you have to handle both explicit namespace and autovivified namespaces (and for the later, does the abspath have a trailing slash or not?).

```ruby
def camelize(basename, abspath)
  return 'API' if abspath.end_with?('foo/api', 'foo/api/', 'foo/api.rb') 
end
```

IMHO it's a bit fragile.

### Proposition

By passing the `cpath` instead, it makes the comparison much simpler and less finicky, e.g

```ruby
def camelize(basename, cpath, abspath)
  return 'API' if cpath == 'MyNamespace::Bar'
end
```

### Questions

When the parent namespace is `Object` I'm passing `nil`, but I guess a case could be made to pass `"Object"` or `"::"` so that this argument is always a string, hence won't require users to check for nil before using string methods.

### Cons

- I implemented it in a backward incompatible way, because I figured Zeitwerk usage, and Inflector customization is likely still limited today. However if you'd like to keep backward compatibility I have a few ideas how to do it.

- As we've learned in another PR, `Module#name` isn't exactly cheap, I'd understand the argument that this would slow down all calls for a minor improvement of the ease of use of the API.

@fxn What do you think?