### PR TITLE
Improve expand_paths memory usage

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -554,7 +554,7 @@ module Zeitwerk
     # @param paths [<String, Pathname, <String, Pathname>>]
     # @return [<String>]
     def expand_paths(paths)
-      Array(paths).flatten.map { |path| File.expand_path(path) }
+      Array(paths).flatten.map! { |path| File.expand_path(path) }
     end
 
     # @param message [String]


### PR DESCRIPTION
It uses 33% less memory when `paths` is not an array and 50% when `paths` is an array.