### PR TITLE
Reduce memory retention by deduplicating strings

### DIFF
--- a/lib/zeitwerk.rb
+++ b/lib/zeitwerk.rb
@@ -1,6 +1,27 @@
 # frozen_string_literal: true
 
 module Zeitwerk
+  class << self
+    # Kernel#require will apply String#-@ on paths before registering them in $LOADED_FEATURES.
+    # That method tries to intern the string to avoid holding onto multiple copies of it.
+    # However there is a couple problem that prevent the deduplication from happening in the vast
+    # majority of cases.
+    #
+    # First tainted string can't be interned, and `File.expand_path` do return tained string.
+    #
+    # Secondly, `Kernel#require` rebuilds a string from what is returned by the file system,
+    # and most of the time that string encoding isn't the application default encoding.
+    PATHS_ENCODING = $LOADED_FEATURES.first.encoding
+    def intern_path!(path)
+      -(path.untaint.force_encoding(PATHS_ENCODING))
+    end
+
+    CPATHS_ENCODING = Object.name.encoding
+    def intern_cname!(cpath)
+      -(cpath.dup.untaint.force_encoding(CPATHS_ENCODING))
+    end
+  end
+
   require_relative "zeitwerk/loader"
   require_relative "zeitwerk/registry"
   require_relative "zeitwerk/explicit_namespace"

--- a/lib/zeitwerk/loader/callbacks.rb
+++ b/lib/zeitwerk/loader/callbacks.rb
@@ -36,7 +36,7 @@ module Zeitwerk::Loader::Callbacks
       autovivified_module = parent.const_set(cname, Module.new)
       log("module #{autovivified_module.name} autovivified from directory #{dir}") if logger
 
-      loaded_cpaths.add(autovivified_module.name)
+      loaded_cpaths.add(cpath(parent, cname))
       on_namespace_loaded(autovivified_module)
     end
   end


### PR DESCRIPTION
### Context

We're currently having troubles shipping Zeitwerk in production because it's causing increased memory usage compared to the classic autoloader.

Memory problems are hard to diagnose, I tried many tools to narrow it down without much success. The most insightful info I have is that the majority of the difference is caused by `T_STRING` (~25% more than classic autoloader).

So I highly suspect the various data structures inside `Zeitwerk::Loader` to be responsible:

```
irb(main):008:0> Zeitwerk::Registry.loaders.first.autoloads.size
=> 7943
irb(main):012:0> Zeitwerk::Registry.loaders.first.shadowed_files.size
=> 2417
irb(main):016:0> Zeitwerk::Registry.loaders.first.loaded_cpaths.size
=> 7862
irb(main):018:0> ActiveSupport::Dependencies.loaded.size
=> 2390
```

(That last one is because some constants are loaded before Zeitwerk kicks in, we're in the process of cleaning that up).

If we compare to the classic autoloader:

```
irb(main):001:0> ActiveSupport::Dependencies.loaded.size
=> 9899
```

### Solutions

This PR is only one of the possible solutions that I want to explore. Ultimately I'd like to release paths references as much as possible in eager loading scenarios, but it's a bit tricky.

In the meantime I'm trying to reduce the impact of keeping all these references

### This PR

Here I'm trying to deduplicate the strings Zeitwerk holds onto. It's aimed at two types:

First I intern `cpath` strings since they are held inside `autoloads`, `loaded_cpaths`, `shadowed_files` and `lazy_subdirs`, so they can be duplicated up to 4 times.

Then, the second part is trickier. The main idea is to intern the paths that will be passed onto `Kernel#require`, so that the entry added into `$LOADED_FEATURES` isn't a duplicate. However it's a bit finicky because `Kernel#require` will call a bunch of FS functions on it like `realpath` etc, and most of these will return a tainted string with ASCII encoding. Tainted strings can't be interned, so we first need to untaint them. Then for the interning to work, the encodings have to match, so we call `force_encoding` as well.

### Considerations

I totally understand that this kinda complexifies the codebase, but IMHO the tradeoff is worth it.

### Further work

It's a bit more complex so I haven't started yet, but similar to what I proposed for the classic autoloader in https://github.com/rails/rails/pull/35747, I think Zeitwerk should try not to hold on all that data when we know it won't be reloading.

I'm unsure how this can be detected, `AS::Dependencies` have a clear `mechanism == :require`, Zeitwerk not so much.

@fxn @rafaelfranca @Edouard-Chin