### PR TITLE
Fix "warning: shadowing outer local variable - dir"

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -359,8 +359,8 @@ module Zeitwerk
           end
         end
 
-        autoloaded_dirs.each do |dir|
-          Registry.unregister_autoload(dir)
+        autoloaded_dirs.each do |autoloaded_dir|
+          Registry.unregister_autoload(autoloaded_dir)
         end
         autoloaded_dirs.clear
 


### PR DESCRIPTION
This warning has been removed in Ruby 2.6. But now this gem supports lower version, so I think it should be fixed.