### PR TITLE
Clear Loader#shadowed_files after eager_load

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -363,6 +363,7 @@ module Zeitwerk
           Registry.unregister_autoload(autoloaded_dir)
         end
         autoloaded_dirs.clear
+        shadowed_files.clear
 
         @eager_loaded = true
       end


### PR DESCRIPTION
As discussed in https://github.com/fxn/zeitwerk/pull/34#issuecomment-481606665, I think `shadowed_files` can be cleared when `eager_load` is called.

As far as I can tell `eager_load` is the only place where we query that data structure, and it can only be effectively called once.

Note that this change breaks lots of tests that use it to make assertions, I can likely fix them but I'd rather do it after I got some 👍 otherwise it's just wasted effort.

cc @fxn 