### PR TITLE
Use caller_locations to get caller filepath

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -413,7 +413,7 @@ module Zeitwerk
       #
       # @return [Zeitwerk::Loader]
       def for_gem
-        called_from = caller[0].split(':')[0]
+        called_from = caller_locations.first.path
         Registry.loader_for_gem(called_from)
       end
 


### PR DESCRIPTION
If `Zeitwerk::Loader.for_gem` is called from a file which contains `:` in its path, `called_from` will be misunderstood.
We can get correct filenames via `caller_locations`.

```ruby
# /tmp/tm:p.rb
require 'zeitwerk'

loader = Zeitwerk::Loader.for_gem
puts loader.tag # => tm
```

I know this rarely happens in actual because bundle path and gem name cannot contain `:`. But my code seems somehow more readable.