### PR TITLE
Avoid building the entire stack to get the caller path

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -414,7 +414,7 @@ module Zeitwerk
       #
       # @return [Zeitwerk::Loader]
       def for_gem
-        called_from = caller_locations.first.path
+        called_from = caller_locations(0, 1).first.path
         Registry.loader_for_gem(called_from)
       end
 


### PR DESCRIPTION
This is a fairly minor performance patch.

`caller` and `caller_location` will allocate one object per stack frame (a `String` and a `Thread::Backtrace::Location` respectively).

But when you know you only want to look at a subset of the call stack, you can pass `start` and `length` arguments, e.g. `caller(0, 1)` to only get the last frame.

No huge deal here as `for_gem` is not really a hotpsot, nor likely to be called from very deep, but the change is so simple that I figured I'd submit it.