### PR TITLE
Handle namespaces being in both eager loaded and non-eager loaded paths

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -481,6 +481,7 @@ module Zeitwerk
         # no matter if it is for a file or a directory. Just remember the
         # subdirectory has to be visited if the namespace is used.
         (lazy_subdirs[cpath] ||= []) << subdir
+        autoloads[subdir] = [parent, cname]
       elsif !cdef?(parent, cname)
         # First time we find this namespace, set an autoload for it.
         (lazy_subdirs[cpath(parent, cname)] ||= []) << subdir

--- a/lib/zeitwerk/loader/callbacks.rb
+++ b/lib/zeitwerk/loader/callbacks.rb
@@ -62,6 +62,7 @@ module Zeitwerk::Loader::Callbacks
   def on_namespace_loaded(namespace)
     if subdirs = lazy_subdirs.delete(namespace.name)
       subdirs.each do |subdir|
+        autoloads.delete(subdir)
         set_autoloads_in_dir(subdir, namespace)
       end
     end

--- a/test/support/loader_test.rb
+++ b/test/support/loader_test.rb
@@ -18,6 +18,7 @@ class LoaderTest < Minitest::Test
       Array(dirs).each do |dir|
         loader.push_dir(dir)
       end
+      loader.logger = method(:puts) if ENV['ZEITWERK_LOG']
       loader.enable_reloading if enable_reloading
       loader.setup            if setup
     end


### PR DESCRIPTION
I found a minor issue with `2.1.5` eager loading. The test case should explain it more precisely but in short:

  - A same namespace can be set to be autovivified from multiple sub directories
  - Only the first one found is registered in `autoloads`, other ones are stored in `lazy_subdirs`.
  - If the first path to be found is in the `eager_load` exclusion list, `eager_load` will ignore all the other directories that should autovivify the namespace. Hence sub constants won't be eagerloaded even though they should.

cc @rafaelfrance @Edouard-Chin @fxn 