### PR TITLE
Add a bit more info about eager loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ loader.eager_load # won't eager load the database adapters
 ```
 
 Eager loading is synchronized and idempotent.
+Eager loading doesn't need inflectors due to using ```require``` for files loading.
 
 If you want to eager load yourself and all dependencies using Zeitwerk, you can broadcast the `eager_load` call to all instances:
 


### PR DESCRIPTION
Hello.
I started using **zeitwerk** in project which has different custom CLI's.
Corresponded code base is in dir ```$PROJECT_ROOT/lib/cli```.
I played with code loading and in first version of boot file uses just ```eager_load``` without any inflectors
I started application and to my surprise it works correctly. All constants and namespaces were loaded right.
Then I removed ```eager_load``` method calling, restart my app, and, as expected, I got error:

```shell
Traceback (most recent call last):
bin/template:6:in `<main>': uninitialized constant CLI (NameError)
Did you mean?  Cli
```

I have fully understanding about runtime loading, why I need inflectors, but I didn't understand why I don't need them when I using eager loading? Using **pry-byebug** I started studying zeitwerk realisation and found that it uses require for eager loading.

I think, like a gem user I shouldn't do so much actions to learn how it works, much easier if it will be in documentation or README.

If you are not agree with me, just close this PR.
Thanks for attention, have a nice day!

