### PR TITLE
Use `Class#name` to compute constant name

### DIFF
--- a/lib/zeitwerk/explicit_namespace.rb
+++ b/lib/zeitwerk/explicit_namespace.rb
@@ -63,7 +63,7 @@ module Zeitwerk
 
       # Note that it makes sense to compute the hash code unconditionally,
       # because the trace point is disabled if cpaths is empty.
-      if loader = cpaths.delete(event.self.name)
+      if loader = cpaths.delete(Class.instance_method(:name).bind(event.self).call)
         loader.on_namespace_loaded(event.self)
         disable_tracer_if_unneeded
       end

--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -636,7 +636,7 @@ module Zeitwerk
     # @param cname [Symbol]
     # @return [String]
     def cpath(parent, cname)
-      parent.equal?(Object) ? cname.to_s : "#{parent.name}::#{cname}"
+      parent.equal?(Object) ? cname.to_s : "#{cname_of(parent)}::#{cname}"
     end
 
     # @param dir [String]
@@ -715,6 +715,12 @@ module Zeitwerk
     def unload_cref(parent, cname)
       parent.send(:remove_const, cname)
       log("#{cpath(parent, cname)} unloaded") if logger
+    end
+
+    # @param klass [Module]
+    # @return [String]
+    def cname_of(klass)
+      Class.instance_method(:name).bind(klass).call
     end
   end
 end

--- a/lib/zeitwerk/loader/callbacks.rb
+++ b/lib/zeitwerk/loader/callbacks.rb
@@ -37,9 +37,9 @@ module Zeitwerk::Loader::Callbacks
     mutex2.synchronize do
       if cref = autoloads.delete(dir)
         autovivified_module = cref[0].const_set(cref[1], Module.new)
-        log("module #{autovivified_module.name} autovivified from directory #{dir}") if logger
+        log("module #{cname_of(autovivified_module)} autovivified from directory #{dir}") if logger
 
-        to_unload[autovivified_module.name] = [dir, cref] if reloading_enabled?
+        to_unload[cname_of(autovivified_module)] = [dir, cref] if reloading_enabled?
 
         # We don't unregister `dir` in the registry because concurrent threads
         # wouldn't find a loader associated to it in Kernel#require and would
@@ -60,7 +60,7 @@ module Zeitwerk::Loader::Callbacks
   # @param namespace [Module]
   # @return [void]
   def on_namespace_loaded(namespace)
-    if subdirs = lazy_subdirs.delete(namespace.name)
+    if subdirs = lazy_subdirs.delete(cname_of(namespace))
       subdirs.each do |subdir|
         set_autoloads_in_dir(subdir, namespace)
       end

--- a/test/lib/zeitwerk/test_callbacks.rb
+++ b/test/lib/zeitwerk/test_callbacks.rb
@@ -52,4 +52,40 @@ class TestCallbacks < LoaderTest
       assert $on_dir_autoloaded_called
     end
   end
+
+  test "autoloading a module that overrides `Module#name`" do
+    def loader.on_namespace_loaded(namespace)
+      if A == namespace
+        $on_namespace_loaded_called = true
+      end
+      super
+    end
+
+    files = [
+      ["a/m.rb", "module A; def self.name; raise; end; M = true; end"],
+    ]
+    with_setup(files) do
+      $on_namespace_loaded_called = false
+      assert A::M
+      assert $on_namespace_loaded_called
+    end
+  end
+
+  test "autoloading a class that overrides `Class#name`" do
+    def loader.on_namespace_loaded(namespace)
+      if B == namespace
+        $on_namespace_loaded_called = true
+      end
+      super
+    end
+
+    files = [
+      ["b/m.rb", "class B < Class.new { def self.name; 'b'; end }; M = true; end"]
+    ]
+    with_setup(files) do
+      $on_namespace_loaded_called = false
+      assert B
+      assert $on_namespace_loaded_called
+    end
+  end
 end

--- a/test/lib/zeitwerk/test_unload.rb
+++ b/test/lib/zeitwerk/test_unload.rb
@@ -104,4 +104,16 @@ class TestUnload < LoaderTest
       assert Zeitwerk::ExplicitNamespace.cpaths["X"] == lb
     end
   end
+
+  test "autoload clears explicit namespaces associated" do
+    files = [
+      ["f/z.rb", "class Z < Class.new { def self.name; 'z'; end }; end"], ["f/z/n.rb", "Z::N = true"],
+    ]
+    with_files(files) do
+      l = new_loader(dirs: "f")
+      assert Zeitwerk::ExplicitNamespace.cpaths["Z"] == l
+      assert Z
+      assert_nil Zeitwerk::ExplicitNamespace.cpaths["Z"]
+    end
+  end
 end


### PR DESCRIPTION
The user defined class/module's `name` may be overridden.