### PR TITLE
Remove const on teardown

### DIFF
--- a/test/lib/zeitwerk/test_eager_load.rb
+++ b/test/lib/zeitwerk/test_eager_load.rb
@@ -69,6 +69,11 @@ class TestEagerLoad < LoaderTest
   end
 
   test "eager loads gems" do
+    on_teardown do
+      remove_const :MyGem
+      delete_loaded_feature "my_gem.rb"
+    end
+
     $my_gem_foo_bar_eager_loaded = false
 
     files = [

--- a/test/lib/zeitwerk/test_for_gem.rb
+++ b/test/lib/zeitwerk/test_for_gem.rb
@@ -2,6 +2,11 @@ require "test_helper"
 
 class TestForGem < LoaderTest
   test "sets things correctly" do
+    on_teardown do
+      remove_const :MyGem
+      delete_loaded_feature "my_gem.rb"
+    end
+
     files = [
       ["my_gem.rb", <<-EOS],
         $for_gem_test_loader = Zeitwerk::Loader.for_gem
@@ -29,6 +34,11 @@ class TestForGem < LoaderTest
   end
 
   test "is idempotent" do
+    on_teardown do
+      remove_const :MyGem
+      delete_loaded_feature "my_gem.rb"
+    end
+
     files = [
       ["my_gem.rb", <<-EOS],
         $for_gem_test_zs << Zeitwerk::Loader.for_gem


### PR DESCRIPTION
In my environment, some tests are failed in random.
This cause is that a const lives after test and it conflicts with the
const definition of other tests.

NOTE: There is an error log.
```
$ bundle exec rake

.........................................................................................................................EEE........................

Finished tests in 1.609877s, 91.9325 tests/s, 209.9539 assertions/s.

Error:
TestGemInflector#test_other_possible_version_rb_are_inflected_normally:
TypeError: MyGem is not a module
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/tmp/lib/my_gem.rb:5:in `<top (required)>'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/lib/zeitwerk/kernel.rb:23:in `require'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/lib/zeitwerk/kernel.rb:23:in `require'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/lib/test_gem_inflector.rb:19:in `block in with_setup'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/support/loader_test.rb:61:in `block in with_files'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/support/loader_test.rb:54:in `chdir'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/support/loader_test.rb:54:in `with_files'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/lib/test_gem_inflector.rb:18:in `with_setup'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/lib/test_gem_inflector.rb:29:in `block in <class:TestGemInflector>'

Error:
TestGemInflector#test_works_as_expected_for_other_files:
TypeError: MyGem is not a module
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/tmp/lib/my_gem.rb:5:in `<top (required)>'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/lib/zeitwerk/kernel.rb:23:in `require'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/lib/zeitwerk/kernel.rb:23:in `require'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/lib/test_gem_inflector.rb:19:in `block in with_setup'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/support/loader_test.rb:61:in `block in with_files'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/support/loader_test.rb:54:in `chdir'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/support/loader_test.rb:54:in `with_files'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/lib/test_gem_inflector.rb:18:in `with_setup'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/lib/test_gem_inflector.rb:33:in `block in <class:TestGemInflector>'

Error:
TestGemInflector#test_the_constant_for_my_gem_version_rb_is_inflected_as_VERSION:
TypeError: MyGem is not a module
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/tmp/lib/my_gem.rb:5:in `<top (required)>'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/lib/zeitwerk/kernel.rb:23:in `require'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/lib/zeitwerk/kernel.rb:23:in `require'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/lib/test_gem_inflector.rb:19:in `block in with_setup'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/support/loader_test.rb:61:in `block in with_files'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/support/loader_test.rb:54:in `chdir'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/support/loader_test.rb:54:in `with_files'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/lib/test_gem_inflector.rb:18:in `with_setup'
    /Users/tricknotes/src/github.com/fxn/zeitwerk/test/lib/test_gem_inflector.rb:25:in `block in <class:TestGemInflector>'

148 tests, 338 assertions, 0 failures, 3 errors, 0 skips
```