### PR TITLE
Stabilize test suite

### DIFF
--- a/test/lib/test_gem_inflector.rb
+++ b/test/lib/test_gem_inflector.rb
@@ -2,6 +2,11 @@ require "test_helper"
 
 class TestGemInflector < LoaderTest
   def with_setup
+    on_teardown do
+      remove_const :MyGem
+      delete_loaded_feature "my_gem.rb", "my_gem/version.rb", "ns/version.rb"
+    end
+
     files = [
       ["lib/my_gem.rb", <<-EOS],
         loader = Zeitwerk::Loader.for_gem

--- a/test/lib/zeitwerk/test_eager_load.rb
+++ b/test/lib/zeitwerk/test_eager_load.rb
@@ -69,6 +69,11 @@ class TestEagerLoad < LoaderTest
   end
 
   test "eager loads gems" do
+    on_teardown do
+      remove_const :MyGem
+      delete_loaded_feature "my_gem.rb", "foo.rb", "bar.rb", "baz.rb"
+    end
+
     $my_gem_foo_bar_eager_loaded = false
 
     files = [

--- a/test/lib/zeitwerk/test_for_gem.rb
+++ b/test/lib/zeitwerk/test_for_gem.rb
@@ -2,6 +2,11 @@ require "test_helper"
 
 class TestForGem < LoaderTest
   test "sets things correctly" do
+    on_teardown do
+      remove_const :MyGem
+      delete_loaded_feature "my_gem.rb", "foo.rb", "bar.rb"
+    end
+
     files = [
       ["my_gem.rb", <<-EOS],
         $for_gem_test_loader = Zeitwerk::Loader.for_gem
@@ -29,6 +34,11 @@ class TestForGem < LoaderTest
   end
 
   test "is idempotent" do
+    on_teardown do
+      remove_const :MyGem
+      delete_loaded_feature "my_gem.rb", "foo.rb"
+    end
+
     files = [
       ["my_gem.rb", <<-EOS],
         $for_gem_test_zs << Zeitwerk::Loader.for_gem
@@ -61,7 +71,7 @@ class TestForGem < LoaderTest
   test "configures the gem inflector by default" do
     on_teardown do
       remove_const :MyGem
-      delete_loaded_feature "my_gem.rb"
+      delete_loaded_feature "my_gem.rb", "foo.rb"
     end
 
     files = [
@@ -85,7 +95,7 @@ class TestForGem < LoaderTest
   test "configures the basename of the root file as loader name" do
     on_teardown do
       remove_const :MyGem
-      delete_loaded_feature "my_gem.rb"
+      delete_loaded_feature "my_gem.rb", "foo.rb"
     end
 
     files = [

--- a/test/lib/zeitwerk/test_require_interaction.rb
+++ b/test/lib/zeitwerk/test_require_interaction.rb
@@ -116,6 +116,11 @@ class TestRequireInteraction < LoaderTest
   end
 
   test "you can autoload yourself in a required file" do
+    on_teardown do
+      remove_const :MyGem
+      delete_loaded_feature "my_gem.rb", "foo.rb"
+    end
+
     files = [
       ["my_gem.rb", <<-EOS],
         loader = Zeitwerk::Loader.new

--- a/test/support/delete_loaded_feature.rb
+++ b/test/support/delete_loaded_feature.rb
@@ -1,7 +1,11 @@
+require 'fileutils'
+
 module DeleteLoadedFeature
-  def delete_loaded_feature(path)
-    $LOADED_FEATURES.delete_if do |realpath|
-      realpath.end_with?(path)
+  def delete_loaded_feature(*paths)
+    Array(paths).each do |path|
+      $LOADED_FEATURES.delete_if do |realpath|
+        realpath.end_with?(path)
+      end
     end
   end
 end


### PR DESCRIPTION
Hello,

A few tests produced red status (Ruby 2.6.3), but only occasionally, once in 5 or 10 runs.

It was produced by leaking tests- some of them did not clean up well after themselves. I found the problem and fixed it.