### PR TITLE
Refactor ExplictlNamespace tracepoint to use a method rather than a block

### DIFF
--- a/lib/zeitwerk/explicit_namespace.rb
+++ b/lib/zeitwerk/explicit_namespace.rb
@@ -54,22 +54,24 @@ module Zeitwerk
           tracer.disable if cpaths.empty?
         end
       end
+
+      def tracepoint_class_callback(event)
+        # If the class is a singleton class, we won't do anything with it so we
+        # can bail out immediately. This is several orders of magnitude faster
+        # than accessing its name.
+        return if event.self.singleton_class?
+
+        # Note that it makes sense to compute the hash code unconditionally,
+        # because the trace point is disabled if cpaths is empty.
+        if loader = cpaths.delete(real_mod_name(event.self))
+          loader.on_namespace_loaded(event.self)
+          disable_tracer_if_unneeded
+        end
+      end
     end
 
     @cpaths = {}
     @mutex  = Mutex.new
-    @tracer = TracePoint.new(:class) do |event|
-      # If the class is a singleton class, we won't do anything with it so we
-      # can bail out immediately. This is several orders of magnitude faster
-      # than accessing its name.
-      next if event.self.singleton_class?
-
-      # Note that it makes sense to compute the hash code unconditionally,
-      # because the trace point is disabled if cpaths is empty.
-      if loader = cpaths.delete(real_mod_name(event.self))
-        loader.on_namespace_loaded(event.self)
-        disable_tracer_if_unneeded
-      end
-    end
+    @tracer = TracePoint.new(:class, &method(:tracepoint_class_callback))
   end
 end


### PR DESCRIPTION
To be honest the main justification for this change is "cosmetic". The TracePoint is one of the main Zeitwerk hotspots, and as such often appear in profiles under the `block in <module:ExplicitNamespace>` name.

I'd prefer if it had a more descriptive name.

There's also probably some extremely marginal performance gain by getting rid of a closure in favor of a method, but it's likely so small that I don't think it's worth benchmarking.