### PR TITLE
Better error for invalid constant names

### DIFF
--- a/lib/zeitwerk/error.rb
+++ b/lib/zeitwerk/error.rb
@@ -4,4 +4,7 @@ module Zeitwerk
 
   class ReloadingDisabledError < Error
   end
+
+  class NameError < ::NameError
+  end
 end

--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -490,6 +490,16 @@ module Zeitwerk
             autoload_subdir(parent, cname, abspath)
           end
         end
+      rescue ::NameError => error
+        raise NameError, <<~MESSAGE
+          #{error.message}
+          This invalid constant name was inferred by #{inflector.class} from #{abspath}.
+
+          You can either:
+            - Mark this path to be ignored.
+            - Rename the file to respect the general convention.
+            - Modify the inflector to handle this case better.
+        MESSAGE
       end
     end
 

--- a/test/lib/zeitwerk/test_exceptions.rb
+++ b/test/lib/zeitwerk/test_exceptions.rb
@@ -44,4 +44,20 @@ class TestExceptions < LoaderTest
       assert_raises(RuntimeError, "foo") { Raises }
     end
   end
+
+  test "raises NameError if the inflector return an invalid constant name for a file" do
+    files = [["foo-bar.rb", "FooBar = 1"]]
+    error = assert_raises Zeitwerk::NameError do
+      with_setup(files) {}
+    end
+    assert_includes error.message, "wrong constant name Foo-bar"
+  end
+
+  test "raises NameError if the inflector return an invalid constant name for a directory" do
+    files = [["foo-bar/baz.rb", "FooBar = 1"]]
+    error = assert_raises NameError do
+      with_setup(files) {}
+    end
+    assert_includes error.message, "wrong constant name Foo-bar"
+  end
 end


### PR DESCRIPTION
Ref: https://github.com/fxn/zeitwerk/issues/72 https://github.com/fxn/zeitwerk/issues/73

People seem to be confused by this error. However it's a totally legitimate error case, and after playing with it a bit I don't think automatically silencing those is a good idea, because if you customize the inflector and include a bug in it, you might have a hard time figuring it out.

However I think what we can do is to improve the error message, so that users better understand what happened, and can fix the issue themselves without opening an issue on GitHub.

NB: doc/writing isn't exactly my *forte*, so alternative error messages are welcome.

Also I chose to subclass `::NameError`, so that it's clearer that it's about Zeitwerk, and also to allow Rails (arguably the main way people we use Zeitwerk) to provide better contextual help.

@fxn WDYT?