### PR TITLE
Expand the caller path in Loader.for_gem

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -438,7 +438,7 @@ module Zeitwerk
       #
       # @return [Zeitwerk::Loader]
       def for_gem
-        called_from = caller_locations(1, 1).first.path
+        called_from = File.expand_path(caller_locations(1, 1).first.path)
         Registry.loader_for_gem(called_from)
       end
 


### PR DESCRIPTION
Fix: https://github.com/fxn/zeitwerk/issues/78

I've put some debug statement, and in short what was happening is:

  - When running the code as `ruby my_gem.rb`, the caller path in the stack is relative ( `caller_locations(0, 1).first.path # => "my_gem.rb"`)
  - Because of this the loader would be registered in `Zeitwerk::Registry.loaders_managing_gems["my_gem.rb"]`.
  - However the autoloads and such would be registered with fully expanded path.
  - So when we reach `module MyGem` it triggers an autoload and load the same file again, causing all sorts of shenanigans.

IMO running a gem like this doesn't make much sense, however since the fix is very simple, and that there might be cases we didn't think about that might cause the caller path to be relative, I think it's a good idea to simply handle it properly.

@fxn @bruno-