### PR TITLE
Add Zeitwerk::SimpleInflector

### DIFF
--- a/lib/zeitwerk.rb
+++ b/lib/zeitwerk.rb
@@ -7,6 +7,7 @@ module Zeitwerk
   require_relative "zeitwerk/explicit_namespace"
   require_relative "zeitwerk/inflector"
   require_relative "zeitwerk/gem_inflector"
+  require_relative "zeitwerk/simple_inflector"
   require_relative "zeitwerk/kernel"
   require_relative "zeitwerk/error"
 end

--- a/lib/zeitwerk/simple_inflector.rb
+++ b/lib/zeitwerk/simple_inflector.rb
@@ -1,0 +1,22 @@
+module Zeitwerk
+  class SimpleInflector < GemInflector # :nodoc:
+    # @param inflections [Hash, nil]
+    def initialize(inflections = nil)
+      @inflections = inflections || {}
+    end
+
+    # @param basename [String]
+    # @param class_name [String]
+    # @return [String]
+    def inflect(basename, class_name)
+      @inflections[basename] = class_name
+    end
+
+    # @param basename [String]
+    # @param abspath [String]
+    # @return [String]
+    def camelize(basename, _abspath)
+      @inflections[basename] || super
+    end
+  end
+end

--- a/test/lib/test_simple_inflector.rb
+++ b/test/lib/test_simple_inflector.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class TestSimpleInflector < Minitest::Test
+  def inflections
+    {
+      "api" => "API",
+      "global_id" => "GlobalID",
+      "mysql" => "MySQL",
+    }
+  end
+
+  test "camelizes using the inflections hash" do
+    inflector = Zeitwerk::SimpleInflector.new(inflections)
+
+    assert_equal "API", inflector.camelize("api", nil)
+    assert_equal "GlobalID", inflector.camelize("global_id", nil)
+    assert_equal "MySQL", inflector.camelize("mysql", nil)
+  end
+
+  test "camelizes basenames not in the inflections hash normally" do
+    inflector = Zeitwerk::SimpleInflector.new(inflections)
+
+    assert_equal "HtmlParser", inflector.camelize("html_parser", nil)
+  end
+
+  test "inflections can be added after initialization" do
+    inflector = Zeitwerk::SimpleInflector.new
+    inflector.inflect 'http', 'HTTP'
+
+    assert_equal "HTTP", inflector.camelize("http", nil)
+  end
+end


### PR DESCRIPTION
Thanks for zeitwerk, much easier than managing requires manually!

I've integrated zeitwerk across a number of different projects and the only pain point I keep hitting is having to write custom inflectors. Whilst it's very flexible, having to write a custom 10+ line class just to handle a few acronyms and abbreviations is a bit onerous.

Given how common acronyms are (the standard library has CGI, CSV, DBM, DRB, ERB, GDBM, IRB, JSON, RSS, SDBM, URI, YAML), I think there is value in including an inflector implementation that can eliminate the need to write a custom inflector for these simple cases.

As a potential solution this PR adds a Zeitwerk::SimpleInflector class which takes a hash of inflections for special cases. As well as basic acronyms this can also handle basenames ending with capitalized words (e.g. global_id), and irregularities like mysql/dynamodb.

Before:

```ruby
class MyInflector < Zeitwerk::Inflector
  def camelize(basename, _abspath)
    case basename
    when "api", "http"
      basename.upcase
    when "global_id"
      "GlobalID"
    when "mysql"
      "MySQL"
    else
      super
    end
  end
end

loader.inflector = MyInflector.new
```

After:

```ruby
loader.inflector = Zeitwerk::SimpleInflector.new({
  'api' => 'API',
  'http' => 'HTTP',
  'global_id' => 'GlobalID',
  'mysql' => 'MySQL'
})
```

Or alternatively:

```ruby
loader.inflector = Zeitwerk::SimpleInflector.new.tap do |inflector|
  inflector.inflect 'api', 'API'
  inflector.inflect 'http', 'HTTP'
  inflector.inflect 'global_id', 'GlobalID'
  inflector.inflect 'mysql', 'MySQL'
end
```