### PR TITLE
Add Zeitwerk::Inflector#inflect method

### DIFF
--- a/lib/zeitwerk/inflector.rb
+++ b/lib/zeitwerk/inflector.rb
@@ -13,7 +13,19 @@ module Zeitwerk
     # @param _abspath [String]
     # @return [String]
     def camelize(basename, _abspath)
-      basename.split('_').map!(&:capitalize).join
+      __inflections[basename] || basename.split('_').map!(&:capitalize).join
+    end
+
+    # @param inflections [Hash]
+    # @return [Hash]
+    def inflect(inflections)
+      __inflections.merge!(inflections)
+    end
+
+    private
+
+    def __inflections
+      @__inflections ||= {}
     end
   end
 end

--- a/test/lib/test_inflector.rb
+++ b/test/lib/test_inflector.rb
@@ -20,4 +20,19 @@ class TestInflector < Minitest::Test
   test "knows nothing about acronyms" do
     assert_equal "HtmlParser", camelize("html_parser")
   end
+
+  test "returns inflections defined using the inflect method" do
+    inflections = {
+      "html_parser" => "HTMLParser",
+      "csv_controller" => "CSVController",
+      "mysql_adapter" => "MySQLAdapter"
+    }
+
+    inflector = Zeitwerk::Inflector.new
+    inflector.inflect(inflections)
+
+    inflections.each do |basename, class_name|
+      assert_equal class_name, inflector.camelize(basename, nil)
+    end
+  end
 end


### PR DESCRIPTION


Adds a Zeitwerk::Inflector#inflect method which can be used to explicitly define custom inflections that take priority over the default Zeitwerk::Inflector#camelize behaviour, per https://github.com/fxn/zeitwerk/pull/88#issuecomment-538712084

Using a double underscored ivar to avoid clashes with existing `@inflections` and using a private reader method to prevent `instance variable @__inflections not initialized` warnings.