### PR TITLE
Enable two optimization for newer rubies

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -623,8 +623,14 @@ module Zeitwerk
     # @param parent [Module]
     # @param cname [Symbol]
     # @return [String, nil]
-    def strict_autoload_path(parent, cname)
-      parent.autoload?(cname) if cdef?(parent, cname)
+    if method(:autoload?).arity == 1
+      def strict_autoload_path(parent, cname)
+        parent.autoload?(cname) if cdef?(parent, cname)
+      end
+    else
+      def strict_autoload_path(parent, cname)
+        parent.autoload?(cname, false)
+      end
     end
 
     # This method is called this way because I prefer `preload` to be the method

--- a/lib/zeitwerk/real_mod_name.rb
+++ b/lib/zeitwerk/real_mod_name.rb
@@ -9,7 +9,13 @@ module Zeitwerk::RealModName
   #
   # @param mod [Class, Module]
   # @return [String, nil]
-  def real_mod_name(mod)
-    UNBOUND_METHOD_MODULE_NAME.bind(mod).call
+  if UnboundMethod.method_defined?(:bind_call)
+    def real_mod_name(mod)
+      UNBOUND_METHOD_MODULE_NAME.bind_call(mod)
+    end
+  else
+    def real_mod_name(mod)
+      UNBOUND_METHOD_MODULE_NAME.bind(mod).call
+    end
   end
 end


### PR DESCRIPTION
Both were added in MRI 2.7.

The first one is `Module#autoload?` now taking a second argument
to restrict the search to the module itself.
https://bugs.ruby-lang.org/issues/15777

The second is the new `UnboundMethod#bind_call` that allows
calling an unbound method without first allocating a `Method`
instance.
https://bugs.ruby-lang.org/issues/15955

@fxn 

cc @rafaelfranca @Edouard-Chin @etiennebarrie