### PR TITLE
support auto-loading from specific module other than Object

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -340,7 +340,7 @@ module Zeitwerk
         break if @eager_loaded
 
         queue = actual_root_dirs.reject { |dir| eager_load_exclusions.member?(dir) }
-        queue.map! { |dir| [Object, dir] }
+        queue.map! { |dir| [parent_for_root_dir(dir), dir] }
         while to_eager_load = queue.shift
           namespace, dir = to_eager_load
 


### PR DESCRIPTION
Hi, 

As Rails style, we usually place namespaced files like this:

```ruby
# app/models/user.rb
class User < ActiveRecord::Base
end

# app/forms/users/sign_up_form.rb
class Users::SignupForm
  include ActiveModel::Model
  attr_accessor :login, :password
  validates :login, :password, presence: true
end

# app/services/users/sign_up.rb
class Users::SignUp
  def call(params)
    form = Users::SignupForm.new(params)
    if form.valid?
      # ...
    else 
      # ...
    end
  end
end
```

Now, I'm going to refactor user-related business logics to individual directory, like this:

```ruby
# domains/users/models/user.rb
class User < ActiveRecord::Base
end

# domains/users/forms/sign_up_form.rb
class Users::SignupForm
  include ActiveModel::Model
  attr_accessor :login, :password
  validates :login, :password, presence: true
end

# domains/users/services/sign_up.rb
class Users::SignUp
  def call(params)
    form = Users::SignupForm.new(params)
    if form.valid?
      # ...
    else 
      # ...
    end
  end
end
```

If push directory `domains` to autoload paths of either Rails or Zeitwerk, it have to define class `Users::Services::SignUp` instead of `Users::SignUp`, this leads me to read Zeitwerk code, then found `Loader#set_autoloads_in_dir` already be designed to pass module/class other than `Object`. So, I can easily add a feature for Loader, support auto-loading from specific module/class:

```ruby
Users = Module.new
loader = Zeitwerk::Loader.new
Dir.glob('domains/users/*').each do |dir|
  loader.push_dir dir, parent: Users if File.directory?(dir)
end
loader.setup
```

if a module is autoloaded from another loader, Symbol or Proc is helpful.

```ruby
# app/domains/users.rb
module Users
end

# app/domains/payments.rb
module Payments
end

loader = Zeitwerk::Loader.new
loader.push_dir 'app/domains'
loader.setup

loader = Zeitwerk::Loader.new
Dir.glob('domains/users/*').each do |dir|
  loader.push_dir dir, parent: :Users if File.directory?(dir)
end
loader.push_dir 'domains/payments', parent: -> { Payments } 
loader.setup
```

I'm not sure whether Zeitwerk is planing to add this feature to `#push_dir`, but I think it's helpful to my project  😄  