### PR TITLE
Raise a Zeitwerk::NameError when a file does not define the expected constant

### DIFF
--- a/lib/zeitwerk/loader/callbacks.rb
+++ b/lib/zeitwerk/loader/callbacks.rb
@@ -14,7 +14,7 @@ module Zeitwerk::Loader::Callbacks
     if logger && cdef?(*cref)
       log("constant #{cpath(*cref)} loaded from file #{file}")
     elsif !cdef?(*cref)
-      raise NameError, "expected file #{file} to define constant #{cpath(*cref)}, but didn't"
+      raise Zeitwerk::NameError, "expected file #{file} to define constant #{cpath(*cref)}, but didn't"
     end
   end
 

--- a/test/lib/zeitwerk/test_exceptions.rb
+++ b/test/lib/zeitwerk/test_exceptions.rb
@@ -5,7 +5,7 @@ class TestExceptions < LoaderTest
     files = [["typo.rb", "TyPo = 1"]]
     with_setup(files) do
       typo_rb = File.realpath("typo.rb")
-      e = assert_raises(NameError) { Typo }
+      e = assert_raises(Zeitwerk::NameError) { Typo }
       assert_equal "expected file #{typo_rb} to define constant Typo, but didn't", e.message
     end
   end
@@ -19,7 +19,7 @@ class TestExceptions < LoaderTest
     files = [["x.rb", "Y = 1"]]
     with_setup(files) do
       x_rb = File.realpath("x.rb")
-      e = assert_raises(NameError) { loader.eager_load }
+      e = assert_raises(Zeitwerk::NameError) { loader.eager_load }
       assert_equal "expected file #{x_rb} to define constant X, but didn't", e.message
     end
   end
@@ -33,7 +33,7 @@ class TestExceptions < LoaderTest
     files = [["cli/x.rb", "module CLI; X = 1; end"]]
     with_setup(files) do
       cli_x_rb = File.realpath("cli/x.rb")
-      e = assert_raises(NameError) { loader.eager_load }
+      e = assert_raises(Zeitwerk::NameError) { loader.eager_load }
       assert_equal "expected file #{cli_x_rb} to define constant Cli::X, but didn't", e.message
     end
   end


### PR DESCRIPTION
### Use case

This is related to https://github.com/rails/rails/pull/37599, in short I'm trying to remove all `require_dependency` usage in Rails, and the last one is here: https://github.com/rails/rails/blob/cb740af5c96ebe0beea01fb8c62e93fb581ad454/actionpack/lib/abstract_controller/helpers.rb#L154

What Rails is doing there is that it `require_dependency` the expected file to know wether the constant doesn't exist, or wether it's loading fails.

So rewrite that code for pure Zeitwerk usage, I need to be able to do the same differentiation, e.g. if I get a `NameError` trying to access `FooHelper`, it can be either `NameError: expected file app/helpers/foo_helper.rb to define constant FooHelper, but didn't` or `NameError: uninitialized constant FooHelper`.

If it's the former I should re-raise it, if it's the later I should ignore it.

@fxn 

cc @Edouard-Chin, @etiennebarrie @rafaelfranca