### PR TITLE
Properly set Zeitwerk::NameError#name

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -494,7 +494,7 @@ module Zeitwerk
         rescue ::NameError => error
           path_type = ruby?(abspath) ? "file" : "directory"
 
-          raise NameError, <<~MESSAGE
+          raise NameError.new(<<~MESSAGE, error.name)
             #{error.message} inferred by #{inflector.class} from #{path_type}
 
               #{abspath}

--- a/lib/zeitwerk/loader/callbacks.rb
+++ b/lib/zeitwerk/loader/callbacks.rb
@@ -14,7 +14,7 @@ module Zeitwerk::Loader::Callbacks
     if logger && cdef?(*cref)
       log("constant #{cpath(*cref)} loaded from file #{file}")
     elsif !cdef?(*cref)
-      raise Zeitwerk::NameError, "expected file #{file} to define constant #{cpath(*cref)}, but didn't"
+      raise Zeitwerk::NameError.new("expected file #{file} to define constant #{cpath(*cref)}, but didn't", cref.last)
     end
   end
 

--- a/test/lib/zeitwerk/test_exceptions.rb
+++ b/test/lib/zeitwerk/test_exceptions.rb
@@ -5,8 +5,9 @@ class TestExceptions < LoaderTest
     files = [["typo.rb", "TyPo = 1"]]
     with_setup(files) do
       typo_rb = File.realpath("typo.rb")
-      e = assert_raises(Zeitwerk::NameError) { Typo }
-      assert_equal "expected file #{typo_rb} to define constant Typo, but didn't", e.message
+      error = assert_raises(Zeitwerk::NameError) { Typo }
+      assert_equal "expected file #{typo_rb} to define constant Typo, but didn't", error.message
+      assert_equal :Typo, error.name
     end
   end
 
@@ -19,8 +20,9 @@ class TestExceptions < LoaderTest
     files = [["x.rb", "Y = 1"]]
     with_setup(files) do
       x_rb = File.realpath("x.rb")
-      e = assert_raises(Zeitwerk::NameError) { loader.eager_load }
-      assert_equal "expected file #{x_rb} to define constant X, but didn't", e.message
+      error = assert_raises(Zeitwerk::NameError) { loader.eager_load }
+      assert_equal "expected file #{x_rb} to define constant X, but didn't", error.message
+      assert_equal :X, error.name
     end
   end
 
@@ -33,8 +35,9 @@ class TestExceptions < LoaderTest
     files = [["cli/x.rb", "module CLI; X = 1; end"]]
     with_setup(files) do
       cli_x_rb = File.realpath("cli/x.rb")
-      e = assert_raises(Zeitwerk::NameError) { loader.eager_load }
-      assert_equal "expected file #{cli_x_rb} to define constant Cli::X, but didn't", e.message
+      error = assert_raises(Zeitwerk::NameError) { loader.eager_load }
+      assert_equal "expected file #{cli_x_rb} to define constant Cli::X, but didn't", error.message
+      assert_equal :X, error.name
     end
   end
 
@@ -50,6 +53,7 @@ class TestExceptions < LoaderTest
     error = assert_raises Zeitwerk::NameError do
       with_setup(files) {}
     end
+    assert_equal :"Foo-bar", error.name
     assert_includes error.message, "wrong constant name Foo-bar"
     assert_includes error.message, "Tell Zeitwerk to ignore this particular file."
   end
@@ -59,6 +63,7 @@ class TestExceptions < LoaderTest
     error = assert_raises Zeitwerk::NameError do
       with_setup(files) {}
     end
+    assert_equal :"Foo-bar", error.name
     assert_includes error.message, "wrong constant name Foo-bar"
     assert_includes error.message, "Tell Zeitwerk to ignore this particular directory."
   end


### PR DESCRIPTION
Context: https://github.com/rails/rails/issues/37650

TL;DR; vanilla `NameError` has a `#name` accessor that is useful to distinguish wether the constant we were trying to load is missing, or if the `NameError` is caused by some dependent code.

e.g. being able to tell the difference between:

```ruby
# foo_controller.rb
class FoosControler # The expected constant doesn't exist
end
```

```ruby
# foo_controller.rb
class FooControler
 ::DoesNotExist # Another constant resolution issue was triggered by loading foo_controlle.rb
end
```

What this patch does is to respect the `NameError#name` contract.

@fxn for review please.

cc @rafaelfranca @etiennebarrie @Edouard-Chin 

