### PR TITLE
Correct GemInflector comment

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -463,9 +463,10 @@ module Zeitwerk
       #
       #   require "zeitwerk"
       #   loader = Zeitwerk::Loader.new
-      #   loader.tag = File.basename(__FILE__, ".rb")
-      #   loader.inflector = Zeitwerk::GemInflector.new
-      #   loader.push_dir(__dir__)
+      #   root_file = __FILE__
+      #   loader.tag = File.basename(root_file, ".rb")
+      #   loader.inflector = Zeitwerk::GemInflector.new(root_file)
+      #   loader.push_dir(File.dirname(root_file))
       #
       # except that this method returns the same object in subsequent calls from
       # the same file, in the unlikely case the gem wants to be able to reload.


### PR DESCRIPTION
GemInflector.new requires an argument, the root file

naming of `root_file`  made with reference to current implementation of the code

## background

my code broke from zeitwerk 2.1.4 to 2.1.5 with the change from `require` to `const_get`.

tracking it down, it turned out it's because I'm doing the following

```
rails_root
  app
  ...etc..
  company_name/lib/company_name.rb
  company_name-integration_name/lib/company_name/integration_name.rb
```

i.e. there's a 'company' gem and various integrations are under that namespace

so, we have a Gemfile with something like

```ruby
  gem 'company_name', path: '.' # require: 'company_name' 
  gem 'company_name-integration_name', path: '.' # require 'company_name/integration_name`
```

the problem is that using the GemInflector now tried to `const_get` IntegrationName under `Object` instead of under `CompanyName`.  

My resolution of that is in 'company_name/integration_name/lib/company_name/integration_name.rb' to reuse the `for_gem` but set the loader one directory up

```ruby
require 'company_name'
require 'company_name/integration_name/version'
require 'company_name/integration_name/rails'
require 'zeitwerk'
loader_root_file = __FILE__
# needs to set the 'root' to 'company_name' not 'company_name/integration_name' so that require 'company_name-integration_name'
# looks up the 'IntegrationName' constant in under the object 'company_name' and not 'Object'
root_file = File.expand_path('..', __FILE__)
loader = Zeitwerk::Registry.loaders_managing_gems[root_file] ||=
  begin
    Zeitwerk::Loader.new.tap do |zl|
      zl.tag = File.basename(loader_root_file, ".rb")
      zl.inflector = Zeitwerk::GemInflector.new(loader_root_file)
      zl.push_dir(File.dirname(root_file))
    end
end
loader.ignore("#{__dir__}/integration_name/rails.rb") # defines an Engine, not Rails
loader.inflector.inflect(
  'company_name' => 'CompanyNAME',
)
module CompanyNAME
  module IntegrationName
  end
end
loader.eager_load
```
```