### PR TITLE
Freeze absolute paths for reduce allocations on file operations

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -616,7 +616,7 @@ module Zeitwerk
       # $LOADED_FEATURES stores real paths since Ruby 2.4.4. We set and save the
       # real path to be able to delete it from $LOADED_FEATURES on unload, and to
       # be able to do a lookup later in Kernel#require for manual require calls.
-      realpath = File.realpath(abspath)
+      realpath = File.realpath(abspath).freeze
       parent.autoload(cname, realpath)
       if logger
         if ruby?(realpath)
@@ -719,7 +719,7 @@ module Zeitwerk
     def ls(dir)
       Dir.foreach(dir) do |basename|
         next if basename.start_with?(".")
-        abspath = File.join(dir, basename)
+        abspath = File.join(dir, basename).freeze
         yield basename, abspath unless ignored_paths.member?(abspath)
       end
     end


### PR DESCRIPTION
Most of the `File` methods cast the paths it receives with [`FilePathValue / rb_get_path`](https://github.com/ruby/ruby/blob/09b936d89cb66e38db46dbe782aa5f22f94656bc/file.c#L244-L248) which ultimately delegate to [`rb_new_str_frozen`](https://github.com/ruby/ruby/blob/09b936d89cb66e38db46dbe782aa5f22f94656bc/file.c#L225-L236) (aliased as `rb_str_new4`).

[`rb_new_str_frozen` could be experessed as `str.frozen? ? str : str.dup`.](https://github.com/ruby/ruby/blob/09b936d89cb66e38db46dbe782aa5f22f94656bc/string.c#L1217-L1222)

So by freezing the paths passed to the various `File.` methods, we
save at least one useless allocation each time, unless the string encoding
is incompatible with the file system.

```
s = __FILE__
alloc = GC.stat[:total_allocated_objects]
File.realpath(s)
p GC.stat[:total_allocated_objects] - alloc # => 3

s = __FILE__.freeze
alloc = GC.stat[:total_allocated_objects]
File.realpath(s)
p GC.stat[:total_allocated_objects] - alloc # => 2
```