### PR TITLE
Use Dir.each_child rather than Dir.foreach

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -720,7 +720,7 @@ module Zeitwerk
     # @yieldparam path [String, String]
     # @return [void]
     def ls(dir)
-      Dir.foreach(dir) do |basename|
+      Dir.each_child(dir) do |basename|
         next if basename.start_with?(".")
 
         abspath = File.join(dir, basename)


### PR DESCRIPTION
`Dir.each_child` don't yield `.` and `..` which we don't care about.

That's an extremely minor improvement, but it took me literally 5 seconds.