### PR TITLE
Capitialize! parts of basename

### DIFF
--- a/lib/zeitwerk/inflector.rb
+++ b/lib/zeitwerk/inflector.rb
@@ -15,7 +15,7 @@ module Zeitwerk
     # @param _abspath [String]
     # @return [String]
     def camelize(basename, _abspath)
-      overrides[basename] || basename.split('_').map!(&:capitalize).join
+      overrides[basename] || basename.split('_').each(&:capitalize!).join
     end
 
     # Configures hard-coded inflections:


### PR DESCRIPTION
```ruby
Basename: point_3d_value
ips benchmark:

Warming up --------------------------------------
            original    46.940k i/100ms
               patch    52.230k i/100ms
Calculating -------------------------------------
            original    502.884k (± 4.0%) i/s -      2.535M in   5.048545s
               patch    559.661k (± 4.7%) i/s -      2.820M in   5.050832s

Comparison:
               patch:   559660.8 i/s
            original:   502883.7 i/s - 1.11x  (± 0.00) slower

memory benchmark:

Calculating -------------------------------------
            original   568.000  memsize (     0.000  retained)
                        11.000  objects (     0.000  retained)
                         6.000  strings (     0.000  retained)
               patch   448.000  memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)

Comparison:
               patch:        448 allocated
            original:        568 allocated - 1.27x more

Basename: api
ips benchmark:

Warming up --------------------------------------
            original   106.231k i/100ms
               patch   117.215k i/100ms
Calculating -------------------------------------
            original      1.075M (± 3.4%) i/s -      5.418M in   5.044269s
               patch      1.173M (± 3.1%) i/s -      5.978M in   5.101064s

Comparison:
               patch:  1173028.5 i/s
            original:  1075274.9 i/s - 1.09x  (± 0.00) slower

memory benchmark:

Calculating -------------------------------------
            original   328.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
               patch   288.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
               patch:        288 allocated
            original:        328 allocated - 1.14x more

Basename: user
ips benchmark:

Warming up --------------------------------------
            original   106.567k i/100ms
               patch   114.295k i/100ms
Calculating -------------------------------------
            original      1.069M (± 2.8%) i/s -      5.435M in   5.089107s
               patch      1.181M (± 3.6%) i/s -      5.943M in   5.039612s

Comparison:
               patch:  1180876.4 i/s
            original:  1068774.7 i/s - 1.10x  (± 0.00) slower

memory benchmark:

Calculating -------------------------------------
            original   328.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
               patch   288.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
               patch:        288 allocated
            original:        328 allocated - 1.14x more

Basename: users_controller
ips benchmark:

Warming up --------------------------------------
            original    68.993k i/100ms
               patch    74.035k i/100ms
Calculating -------------------------------------
            original    699.314k (± 3.6%) i/s -      3.519M in   5.038217s
               patch    754.746k (± 3.9%) i/s -      3.776M in   5.010223s

Comparison:
               patch:   754745.9 i/s
            original:   699314.5 i/s - 1.08x  (± 0.00) slower

memory benchmark:

Calculating -------------------------------------
            original   448.000  memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         5.000  strings (     0.000  retained)
               patch   368.000  memsize (     0.000  retained)
                         6.000  objects (     0.000  retained)
                         3.000  strings (     0.000  retained)

Comparison:
               patch:        368 allocated
            original:        448 allocated - 1.22x more

Basename: super_users_controller
ips benchmark:

Warming up --------------------------------------
            original    52.472k i/100ms
               patch    56.658k i/100ms
Calculating -------------------------------------
            original    521.691k (± 3.0%) i/s -      2.624M in   5.033469s
               patch    563.263k (± 3.0%) i/s -      2.833M in   5.033886s

Comparison:
               patch:   563262.6 i/s
            original:   521690.6 i/s - 1.08x  (± 0.00) slower

memory benchmark:

Calculating -------------------------------------
            original   568.000  memsize (     0.000  retained)
                        11.000  objects (     0.000  retained)
                         7.000  strings (     0.000  retained)
               patch   448.000  memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)

Comparison:
               patch:        448 allocated
            original:        568 allocated - 1.27x more

Basename: very_super_users_controller
ips benchmark:

Warming up --------------------------------------
            original    37.528k i/100ms
               patch    41.258k i/100ms
Calculating -------------------------------------
            original    371.596k (± 3.0%) i/s -      1.876M in   5.054234s
               patch    398.737k (± 2.6%) i/s -      2.022M in   5.073531s

Comparison:
               patch:   398737.4 i/s
            original:   371595.9 i/s - 1.07x  (± 0.00) slower

memory benchmark:

Calculating -------------------------------------
            original   848.000  memsize (     0.000  retained)
                        14.000  objects (     0.000  retained)
                         9.000  strings (     0.000  retained)
               patch   688.000  memsize (     0.000  retained)
                        10.000  objects (     0.000  retained)
                         5.000  strings (     0.000  retained)

Comparison:
               patch:        688 allocated
            original:        848 allocated - 1.23x more
```