### PR TITLE
Add truffleruby-head to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ rvm:
   - ruby-head
   - jruby-head
   - truffleruby
+  - truffleruby-head
 matrix:
   allow_failures:
     - rvm: jruby-head
+    - rvm: truffleruby-head
     - rvm: truffleruby


### PR DESCRIPTION
Please add truffleruby-head to travis CI so we can see the status of the latest TruffleRuby. 