### PR TITLE
Use __send__ instead of send

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -777,13 +777,13 @@ module Zeitwerk
 
     # @sig (Module, Symbol) -> void
     def unload_autoload(parent, cname)
-      parent.send(:remove_const, cname)
+      parent.__send__(:remove_const, cname)
       log("autoload for #{cpath(parent, cname)} removed") if logger
     end
 
     # @sig (Module, Symbol) -> void
     def unload_cref(parent, cname)
-      parent.send(:remove_const, cname)
+      parent.__send__(:remove_const, cname)
       log("#{cpath(parent, cname)} unloaded") if logger
     end
   end


### PR DESCRIPTION
We had an issue in our codebase where we would see a mysterious `ArgumentError - wrong number of arguments (given 2, expected 3)` that was being traced to this line:

    (gem) zeitwerk-2.3.0/lib/zeitwerk/loader.rb:796:in `unload_autoload'

We finally realized that this is down to a class in our codebase that defines its own `self.send` method (that does something unrelated, hence the mismatch in arity). 

Now I'm completely aware that this is bad practice and we're going to fix the offending class, but it's also true that the resulting error message is very confusing and it's not immediately clear how to fix it.

If zeitwerk was to use `__send__` instead of `send` it would avoid this issue. I'm not sure if there are any downsides to this, or if this should be merged at all -- consider this pull request an invitation for a discussion.