### PR TITLE
Add Ruby 3.0 on CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
   - ruby-head
   - jruby-head
   - truffleruby
@@ -21,4 +22,4 @@ matrix:
       rvm: truffleruby
     - arch: ppc64le
       rvm: truffleruby-head
-      
+


### PR DESCRIPTION
Also, I'm wondering whether `truffleruby` has been added to "allow_failures"
category by mistake? Suppose we should add `truffleruby-head` instead.
Since tests for `truffleruby` are green for a couple of the last builds
https://github.com/fxn/zeitwerk/runs/1577391820