### PR TITLE
Minor performance optimizations in Loader#cperf

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -717,7 +717,7 @@ module Zeitwerk
 
     # @sig (Module, Symbol) -> String
     def cpath(parent, cname)
-      parent.equal?(Object) ? cname.to_s : "#{real_mod_name(parent)}::#{cname}"
+      Object == parent ? cname.to_s : "#{real_mod_name(parent)}::#{cname}"
     end
 
     # @sig (String) { (String, String) -> void } -> void

--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -716,8 +716,14 @@ module Zeitwerk
     end
 
     # @sig (Module, Symbol) -> String
-    def cpath(parent, cname)
-      Object == parent ? cname.to_s : "#{real_mod_name(parent)}::#{cname}"
+    if Symbol.method_defined?(:name)
+      def cpath(parent, cname)
+        Object == parent ? cname.name : "#{real_mod_name(parent)}::#{cname.name}"
+      end
+    else
+      def cpath(parent, cname)
+        Object == parent ? cname.to_s : "#{real_mod_name(parent)}::#{cname}"
+      end
     end
 
     # @sig (String) { (String, String) -> void } -> void


### PR DESCRIPTION
I was surprised to see `BasicObject.equal?` show up in my profiles

Instead we can use `==`, It's very slightly faster because MRI has a dedicated `opt_eq` opcode, and by calling in on `Object` it's just as unlikely to be overridden than `equal?`.

```ruby
require 'benchmark/ips'

parent = Object
Benchmark.ips do |x|
  x.report('==') { Object == parent  }
  x.report('equal?') { Object.equal?(parent)  }
  x.compare!
end
```

```
Warming up --------------------------------------
                  ==     2.299M i/100ms
              equal?     1.951M i/100ms
Calculating -------------------------------------
                  ==     22.960M (± 1.0%) i/s -    114.964M in   5.007555s
              equal?     19.374M (± 1.3%) i/s -     97.551M in   5.036074s

Comparison:
                  ==: 22960357.5 i/s
              equal?: 19373931.9 i/s - 1.19x  (± 0.00) slower
```

Overall the gain is small, but the change is trivial so why not.


The second patch is to save a few allocations starting from Ruby 3.0, I hadn't noticed it until now because we run with https://github.com/Shopify/symbol-fstring.