### PR TITLE
Allow to disable symlink resolution

### DIFF
--- a/test/lib/zeitwerk/test_push_dir.rb
+++ b/test/lib/zeitwerk/test_push_dir.rb
@@ -38,4 +38,16 @@ class TesPushDir < LoaderTest
     e = assert_raises(Zeitwerk::Error) { loader.push_dir(".", namespace: :foo) }
     assert_equal ":foo is not a class or module object, should be", e.message
   end
+
+  test "resolve the real path even with resolve_symlinks = false" do
+    files = [["real/x.rb", "X = true"]]
+    with_files(files) do
+      FileUtils.ln_s("real", "symlink")
+      loader.resolve_symlinks = false
+      loader.push_dir("symlink")
+      loader.setup
+
+      assert_equal File.realpath("real/x.rb"), Object.autoload?(:X)
+    end
+  end
 end


### PR DESCRIPTION
Zeiwerk end up calling `File.realpath` a lot to not trip on symlinsk, and that is a relatively expensive syscall, even more so on systems with slow file systems.

For advanced users who know their load paths don't contain any symlinks, it can be beneficial to only resolve the root directories.

In our app we spend `~1.7%` of boot time in `File.realpath`, even though I know for a fact that there isn't a single symlink.

```
$ stackprof ~/Downloads/stackprof-shopify-boot-production-cpu.dump --method=File.realpath
File.realpath (<cfunc>:1)
  samples:   757 self (1.7%)  /    758 total (1.7%)
  callers:
     351  (   46.3%)  Zeitwerk::Loader#set_autoload
     349  (   46.0%)  Zeitwerk::Loader#eager_load
      38  (    5.0%)  Bootsnap::LoadPathCache::RealpathCache#find_file
       9  (    1.2%)  Bootsnap::CompileCache::YAML::Patch#load_file
       9  (    1.2%)  Bootsnap::LoadPathCache::Cache#initialize
       1  (    0.1%)  Rails::Engine.find_root_with_flag
       1  (    0.1%)  Google::Cloud.loaded_files
```

It would be nice it there was an "advanced" setting to turn this off. 