### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Introduction](#introduction)
 - [Synopsis](#synopsis)
 - [File structure](#file-structure)
+  - [Setting a custom namespace explicitly](#setting-a-custom-namespace-explicitly)
   - [Implicit namespaces](#implicit-namespaces)
   - [Explicit namespaces](#explicit-namespaces)
   - [Collapsing directories](#collapsing-directories)
@@ -139,6 +140,9 @@ Zeitwerk understands that their respective files and subdirectories belong to th
 app/models/user.rb                        -> User
 app/controllers/admin/users_controller.rb -> Admin::UsersController
 ```
+
+<a id="markdown-setting-a-custom-namespace-explicitly" name="setting-a-custom-namespace-explicitly"></a>
+### Setting a custom namespace explicitly
 
 Alternatively, you can associate a custom namespace to a root directory by passing a class or module object in the optional `namespace` keyword argument.
 


### PR DESCRIPTION
Add a heading "Setting a custom namespace explicitly" under
"File structure" because it's a distinct feature so it deserves its own
section. This way it will be easier to spot it. I was looking for this
feature specifically in the README and missed it, because I clicked on
"Explicit namespaces" header and it was not there, so I assumed it's not
supported.