### PR TITLE
Load zeitwerk's `VERSION` constant

### DIFF
--- a/lib/zeitwerk.rb
+++ b/lib/zeitwerk.rb
@@ -10,4 +10,5 @@ module Zeitwerk
   require_relative "zeitwerk/gem_inflector"
   require_relative "zeitwerk/kernel"
   require_relative "zeitwerk/error"
+  require_relative "zeitwerk/version"
 end


### PR DESCRIPTION
Was just working on https://github.com/testdouble/good-migrations/issues/9 and noticed that `Zeitwerk::VERSION` is not available by default, so it seemed like something that should be loaded with the rest of the gem.

Feel free to take it or leave it!