### PR TITLE
Convert `Zeitwerk::Loader::Config#tag` from accessor to reader

### DIFF
--- a/lib/zeitwerk/loader/config.rb
+++ b/lib/zeitwerk/loader/config.rb
@@ -74,7 +74,7 @@ module Zeitwerk::Loader::Config
   # This is useful in order to be able to distinguish loaders in logging.
   #
   # @sig String
-  attr_accessor :tag
+  attr_reader :tag
 
   def initialize
     @initialized_at         = Time.now


### PR DESCRIPTION
This commit converts the `#tag` `attr_acessor` into an `attr_reader` to
make the library warning free. This is caused by the re-definition of
`Zeitwerk::Loader::Config#tag=` further down in the same file.

As we are defining a custom writer, we can convert the `attr_accessor`
into an `attr_reader` safely.