### PR TITLE
Add frozen_literal_magic comment in all files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake/testtask'
 
 task :default => :test

--- a/lib/zeitwerk/autoloads.rb
+++ b/lib/zeitwerk/autoloads.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Zeitwerk
   # @private
   class Autoloads

--- a/lib/zeitwerk/error.rb
+++ b/lib/zeitwerk/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Zeitwerk
   class Error < StandardError
   end

--- a/lib/zeitwerk/explicit_namespace.rb
+++ b/lib/zeitwerk/explicit_namespace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Zeitwerk
   # Centralizes the logic for the trace point used to detect the creation of
   # explicit namespaces, needed to descend into matching subdirectories right

--- a/lib/zeitwerk/loader/callbacks.rb
+++ b/lib/zeitwerk/loader/callbacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Zeitwerk::Loader::Callbacks
   include Zeitwerk::RealModName
 

--- a/lib/zeitwerk/loader/config.rb
+++ b/lib/zeitwerk/loader/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "set"
 require "securerandom"
 

--- a/lib/zeitwerk/loader/helpers.rb
+++ b/lib/zeitwerk/loader/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Zeitwerk::Loader::Helpers
   private
 

--- a/lib/zeitwerk/real_mod_name.rb
+++ b/lib/zeitwerk/real_mod_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Zeitwerk::RealModName
   UNBOUND_METHOD_MODULE_NAME = Module.instance_method(:name)
   private_constant :UNBOUND_METHOD_MODULE_NAME

--- a/test/lib/test_gem_inflector.rb
+++ b/test/lib/test_gem_inflector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestGemInflector < LoaderTest

--- a/test/lib/test_inflector.rb
+++ b/test/lib/test_inflector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestInflector < Minitest::Test

--- a/test/lib/test_real_mod_name.rb
+++ b/test/lib/test_real_mod_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestRealModName < Minitest::Test

--- a/test/lib/zeitwerk/test_all_dirs.rb
+++ b/test/lib/zeitwerk/test_all_dirs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestAllDirs < LoaderTest

--- a/test/lib/zeitwerk/test_ancestors.rb
+++ b/test/lib/zeitwerk/test_ancestors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 # The following properties are not supported by the classic Rails autoloader.

--- a/test/lib/zeitwerk/test_autoloads.rb
+++ b/test/lib/zeitwerk/test_autoloads.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestAutoloads < Minitest::Test

--- a/test/lib/zeitwerk/test_autovivification.rb
+++ b/test/lib/zeitwerk/test_autovivification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestAutovivification < LoaderTest

--- a/test/lib/zeitwerk/test_callbacks.rb
+++ b/test/lib/zeitwerk/test_callbacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestCallbacks < LoaderTest

--- a/test/lib/zeitwerk/test_collapse.rb
+++ b/test/lib/zeitwerk/test_collapse.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "set"
 

--- a/test/lib/zeitwerk/test_conflicting_directory.rb
+++ b/test/lib/zeitwerk/test_conflicting_directory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestConflictingDirectory < LoaderTest

--- a/test/lib/zeitwerk/test_eager_load.rb
+++ b/test/lib/zeitwerk/test_eager_load.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "fileutils"
 

--- a/test/lib/zeitwerk/test_exceptions.rb
+++ b/test/lib/zeitwerk/test_exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestExceptions < LoaderTest

--- a/test/lib/zeitwerk/test_explicit_namespace.rb
+++ b/test/lib/zeitwerk/test_explicit_namespace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestExplicitNamespace < LoaderTest

--- a/test/lib/zeitwerk/test_for_gem.rb
+++ b/test/lib/zeitwerk/test_for_gem.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestForGem < LoaderTest

--- a/test/lib/zeitwerk/test_ignore.rb
+++ b/test/lib/zeitwerk/test_ignore.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "set"
 

--- a/test/lib/zeitwerk/test_logging.rb
+++ b/test/lib/zeitwerk/test_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestLogging < LoaderTest

--- a/test/lib/zeitwerk/test_marshal.rb
+++ b/test/lib/zeitwerk/test_marshal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestMarshal < LoaderTest

--- a/test/lib/zeitwerk/test_multiple.rb
+++ b/test/lib/zeitwerk/test_multiple.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestMultiple < LoaderTest

--- a/test/lib/zeitwerk/test_nested_root_directories.rb
+++ b/test/lib/zeitwerk/test_nested_root_directories.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestNestedRootDirectories < LoaderTest

--- a/test/lib/zeitwerk/test_push_dir.rb
+++ b/test/lib/zeitwerk/test_push_dir.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "pathname"
 

--- a/test/lib/zeitwerk/test_reloading.rb
+++ b/test/lib/zeitwerk/test_reloading.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "fileutils"
 

--- a/test/lib/zeitwerk/test_require_interaction.rb
+++ b/test/lib/zeitwerk/test_require_interaction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "pathname"
 

--- a/test/lib/zeitwerk/test_ruby_compatibility.rb
+++ b/test/lib/zeitwerk/test_ruby_compatibility.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "pathname"
 

--- a/test/lib/zeitwerk/test_shadowed.rb
+++ b/test/lib/zeitwerk/test_shadowed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestShadowed < LoaderTest

--- a/test/lib/zeitwerk/test_sti_old_school_workaround.rb
+++ b/test/lib/zeitwerk/test_sti_old_school_workaround.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 # Rails applications are expected to preload STIs. Using requires is the old

--- a/test/lib/zeitwerk/test_top_level.rb
+++ b/test/lib/zeitwerk/test_top_level.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestTopLevel < LoaderTest

--- a/test/lib/zeitwerk/test_unload.rb
+++ b/test/lib/zeitwerk/test_unload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestUnload < LoaderTest

--- a/test/lib/zeitwerk/test_unloadable_cpath.rb
+++ b/test/lib/zeitwerk/test_unloadable_cpath.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "set"
 

--- a/test/lib/zeitwerk/test_unregister.rb
+++ b/test/lib/zeitwerk/test_unregister.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TestUnregister < LoaderTest

--- a/test/support/delete_loaded_feature.rb
+++ b/test/support/delete_loaded_feature.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DeleteLoadedFeature
   def delete_loaded_feature(path)
     $LOADED_FEATURES.delete_if do |abspath|

--- a/test/support/loader_test.rb
+++ b/test/support/loader_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LoaderTest < Minitest::Test
   TMP_DIR = File.expand_path("../tmp", __dir__)
 

--- a/test/support/on_teardown.rb
+++ b/test/support/on_teardown.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OnTeardown
   def on_teardown
     define_singleton_method(:teardown) do

--- a/test/support/remove_const.rb
+++ b/test/support/remove_const.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RemoveConst
   def remove_const(cname, from: Object)
     from.send(:remove_const, cname)

--- a/test/support/test_macro.rb
+++ b/test/support/test_macro.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TestMacro
   def test(description, &block)
     method_name = "test_#{description}".gsub(/\W/, "_")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "minitest/autorun"
 require "minitest/focus"
 

--- a/zeitwerk.gemspec
+++ b/zeitwerk.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/zeitwerk/version"
 
 Gem::Specification.new do |spec|


### PR DESCRIPTION
I was surprised to notice Zeitwerk was quite high up in boot allocation reports:

```
allocated memory by gem
-----------------------------------
....
  41.42 MB  zeitwerk-2.5.0.beta3

Allocated String Report
-----------------------------------
   2.20 MB   54947  ".rb"
             48372  zeitwerk-2.5.0.beta3/lib/zeitwerk/loader/helpers.rb:30
...
 
   1.98 MB   49428  "."
             47301  zeitwerk-2.5.0.beta3/lib/zeitwerk/loader/helpers.rb:40
...
 
 654.84 kB   16371  "/"
             10107  zeitwerk-2.5.0.beta3/lib/zeitwerk/loader/config.rb:252
...

```

It's not a big deal, but this simple change can reduce Zeitwerk allocations by over 10%, so IMHO it's worth it.

Also some files had it, others didn't, so it makes sense for consistency sake. 