### PR TITLE
Update the Kernel#require comment about prepend

### DIFF
--- a/lib/zeitwerk/kernel.rb
+++ b/lib/zeitwerk/kernel.rb
@@ -17,7 +17,7 @@ module Kernel
   #
   # We cannot decorate with prepend + super because Kernel has already been
   # included in Object, and changes in ancestors don't get propagated into
-  # already existing ancestor chains.
+  # already existing ancestor chains on Ruby < 3.0.
   alias_method :zeitwerk_original_require, :require
 
   # @sig (String) -> true | false


### PR DESCRIPTION
Ref: https://github.com/Shopify/bootsnap/pull/389

I wondered the same, and was surprised to see it work. Turns out it was fixed recently.