### PR TITLE
Enable warnings when running tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,5 @@ task :default => :test
 Rake::TestTask.new do |t|
   t.test_files = Dir.glob('test/lib/**/test_*.rb')
   t.libs << "test"
+  t.warning = true
 end


### PR DESCRIPTION
This PR enables rake's test task to opt into running the test suite with
warnings, this is to avoid warnings sneaking into the library.

Illustrative example:

```
% git diff
diff --git a/lib/zeitwerk.rb b/lib/zeitwerk.rb
index a1335d1..615d516 100644
--- a/lib/zeitwerk.rb
+++ b/lib/zeitwerk.rb
@@ -16,6 +16,7 @@ module Zeitwerk
   # @experimental
   # @sig () -> void
   def self.with_loader
+    a = 1
     loader = Zeitwerk::Loader.new
     yield loader
   ensure
% bundle exec rake
/Users/teo/src/github.com/fxn/zeitwerk/lib/zeitwerk.rb:19: warning: assigned but unused variable - a
... output omitted ...
```