### PR TITLE
Eager load constants in a consistent order

### DIFF
--- a/lib/zeitwerk/loader/helpers.rb
+++ b/lib/zeitwerk/loader/helpers.rb
@@ -15,7 +15,7 @@ module Zeitwerk::Loader::Helpers
 
   # @sig (String) { (String, String) -> void } -> void
   def ls(dir)
-    Dir.each_child(dir) do |basename|
+    Dir.children(dir).sort.each do |basename|
       next if hidden?(basename)
 
       abspath = File.join(dir, basename)


### PR DESCRIPTION
The yield order of `Dir.each_entry` is directly dependent from the file system implementation. On macOS they will be yielded in alphabetical order, because that's how HFS is implemented.

However on Linux, different file system expose different orders. Most commonly, files are iterated with the last modified first, which across a fleet of server is akin to "random".

This small disrependency can cause order dependent code to fail. Arguably, it's the user code that is faulty and should be fixed (I agree), but even then, a predictable order makes it easier to debug.

For that same reason, since Ruby 3 `Dir[]` is sorted: https://bugs.ruby-lang.org/issues/8709

@fxn what do you think?

cc @jeromegn