### PR TITLE
Allow loader for gem to specify root file

### DIFF
--- a/lib/zeitwerk/gem_loader.rb
+++ b/lib/zeitwerk/gem_loader.rb
@@ -23,6 +23,7 @@ module Zeitwerk
       @lib                 = File.dirname(root_file)
       @warn_on_extra_files = warn_on_extra_files
 
+      ignore(root_file) if @tag.include?("-")
       push_dir(@lib)
     end
 

--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -306,9 +306,9 @@ module Zeitwerk
       # is private, client code can only rely on the interface.
       #
       # @sig (bool) -> Zeitwerk::GemLoader
-      def for_gem(warn_on_extra_files: true)
+      def for_gem(warn_on_extra_files: true, root_file: nil)
         called_from = caller_locations(1, 1).first.path
-        Registry.loader_for_gem(called_from, warn_on_extra_files: warn_on_extra_files)
+        Registry.loader_for_gem(root_file || called_from, warn_on_extra_files: warn_on_extra_files)
       end
 
       # Broadcasts `eager_load` to all loaders.

--- a/test/lib/zeitwerk/test_for_gem.rb
+++ b/test/lib/zeitwerk/test_for_gem.rb
@@ -245,4 +245,24 @@ class TestForGem < LoaderTest
       assert_includes err, "Zeitwerk::Loader.for_gem(warn_on_extra_files: false)"
     end
   end
+
+  test "allows specification of root file" do
+    files = [["lib/my_gem-extension.rb", "require \"my_gem/extension\""], ["lib/my_gem/extension.rb", <<~EOS]]
+      root_file = File.expand_path("../my_gem-extension.rb", __dir__)
+      loader = Zeitwerk::Loader.for_gem(root_file: root_file, warn_on_extra_files: false)
+      loader.enable_reloading
+      loader.setup
+
+      module MyGem
+        module Extension
+        end
+      end
+    EOS
+    with_my_gem(files, false) do
+      _out, err = capture_io do
+        assert require("my_gem-extension")
+      end
+      assert_empty err
+    end
+  end
 end


### PR DESCRIPTION
I tried adding Zeitwerk to dry-monitor in https://github.com/dry-rb/dry-monitor/pull/47 and I noticed that the gem loader doesn't support specifying a root file if the loader isn't created in the root file. This use-case is common for gems that extend functionality of other gems (eg. dry-monitor, sprockets-rails, rubocop-rails). 

This patch would allow the Zeitwerk loader I made to be simplified from:
```
@loader ||= Zeitwerk::Loader.new.tap do |loader|
  root = File.expand_path("..", __dir__)
  loader.tag = "dry-monitor"
  loader.inflector = Zeitwerk::GemInflector.new("#{root}/dry-monitor.rb")
  loader.push_dir(root)
  loader.ignore("#{root}/dry-monitor.rb")
  loader.inflector.inflect "sql" => "SQL"
end
```
to:
```
@loader ||= Zeitwerk::Loader.for_gem(root_file: root_file, warn_on_extra_files: false).tap do |loader|
  loader.inflector.inflect "sql" => "SQL"
end
# ...
def root_file
  File.expand_path("../dry-monitor.rb", __dir__)
end
```

Does this make sense?