### PR TITLE
Document namespace values for Zeitwerk::Loader::Config#root_dirs

### DIFF
--- a/lib/zeitwerk/loader/config.rb
+++ b/lib/zeitwerk/loader/config.rb
@@ -5,18 +5,20 @@ require "securerandom"
 
 module Zeitwerk::Loader::Config
   # Absolute paths of the root directories. Stored in a hash to preserve
-  # order, easily handle duplicates, and also be able to have a fast lookup,
-  # needed for detecting nested paths.
+  # order, easily handle duplicates, to have a fast lookup needed for
+  # detecting nested paths and to store custom namespace as value (default
+  # is Object.
   #
-  #   "/Users/fxn/blog/app/assets"   => true,
-  #   "/Users/fxn/blog/app/channels" => true,
+  #   "/Users/fxn/blog/app/assets"   => Object,
+  #   "/Users/fxn/blog/app/channels" => Object,
+  #   "/Users/fxn/blog/adapters" => ActiveJob::QueueAdapters,
   #   ...
   #
   # This is a private collection maintained by the loader. The public
   # interface for it is `push_dir` and `dirs`.
   #
   # @private
-  # @sig Hash[String, true]
+  # @sig Hash[String, Module]
   attr_reader :root_dirs
 
   # @sig #camelize

--- a/lib/zeitwerk/loader/config.rb
+++ b/lib/zeitwerk/loader/config.rb
@@ -6,12 +6,12 @@ require "securerandom"
 module Zeitwerk::Loader::Config
   # Absolute paths of the root directories. Stored in a hash to preserve
   # order, easily handle duplicates, to have a fast lookup needed for
-  # detecting nested paths and to store custom namespace as value (default
-  # is Object.
+  # detecting nested paths and to store custom namespaces as values (default
+  # is Object).
   #
   #   "/Users/fxn/blog/app/assets"   => Object,
   #   "/Users/fxn/blog/app/channels" => Object,
-  #   "/Users/fxn/blog/adapters" => ActiveJob::QueueAdapters,
+  #   "/Users/fxn/blog/adapters"     => ActiveJob::QueueAdapters,
   #   ...
   #
   # This is a private collection maintained by the loader. The public

--- a/lib/zeitwerk/loader/config.rb
+++ b/lib/zeitwerk/loader/config.rb
@@ -5,9 +5,8 @@ require "securerandom"
 
 module Zeitwerk::Loader::Config
   # Absolute paths of the root directories. Stored in a hash to preserve
-  # order, easily handle duplicates, to have a fast lookup needed for
-  # detecting nested paths and to store custom namespaces as values (default
-  # is Object).
+  # order, easily handle duplicates, have a fast lookup needed for detecting
+  # nested paths, and store custom namespaces as values.
   #
   #   "/Users/fxn/blog/app/assets"   => Object,
   #   "/Users/fxn/blog/app/channels" => Object,


### PR DESCRIPTION
Since b5a63c2c00e3f908d78378a5a59659702c175f23 root_dirs does not have `true` as values, but namespace module instead.