### PR TITLE
Fix Erroenous Conflicting Directory Error

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -445,15 +445,15 @@ module Zeitwerk
           next if loader == self
           next if loader.ignores?(dir)
 
-          dir = dir + "/"
+          suffixed_dir = dir + "/"
           loader.root_dirs.each do |root_dir, _namespace|
             next if ignores?(root_dir)
 
             root_dir = root_dir + "/"
-            if dir.start_with?(root_dir) || root_dir.start_with?(dir)
+            if suffixed_dir.start_with?(root_dir) || root_dir.start_with?(suffixed_dir)
               require "pp" # Needed for pretty_inspect, even in Ruby 2.5.
               raise Error,
-                "loader\n\n#{pretty_inspect}\n\nwants to manage directory #{dir.chop}," \
+                "loader\n\n#{pretty_inspect}\n\nwants to manage directory #{dir}," \
                 " which is already managed by\n\n#{loader.pretty_inspect}\n"
               EOS
             end

--- a/test/lib/zeitwerk/test_conflicting_directory.rb
+++ b/test/lib/zeitwerk/test_conflicting_directory.rb
@@ -60,6 +60,16 @@ class TestConflictingDirectory < LoaderTest
     assert loader.push_dir(dir)
   end
 
+  test "does not raise if a second existing loader ignores the directory (dir)" do
+    # Ensure this loader is loaded
+    existing_loader
+    second_existing_loader = new_loader(setup: false)
+    second_existing_loader.push_dir(parent)
+    second_existing_loader.ignore(dir)
+
+    assert loader.push_dir(dir)
+  end
+
   test "does not raise if an existing loader ignores the directory (glob pattern)" do
     existing_loader.push_dir(parent)
     existing_loader.ignore("#{parent}/*")


### PR DESCRIPTION
The current implementation ends up clobbering the `dir` variable
after checking the first loader in `Registry.loaders`.  As a result
if you have multiple loaders, the `loader.ignores?(dir)` check
will be guaranteed to fail even if the loader actually ignores
the directory, since there is a stray `/` at the end of the path.

