### PR TITLE
Add minitest-proveit to force assertions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ gemspec
 gem "rake"
 gem "minitest"
 gem "minitest-focus"
+gem "minitest-proveit"
 gem "minitest-reporters"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@
 
 require "minitest/autorun"
 require "minitest/focus"
+require "minitest/proveit"
 
 require "minitest/reporters"
 Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new)
@@ -20,4 +21,6 @@ Minitest::Test.class_eval do
   include DeleteLoadedFeature
   include RemoveConst
   include OnTeardown
+
+  prove_it!
 end


### PR DESCRIPTION
This PR adds minitest-proveit to force that all tests executes some kind
of assertion, and if they do not - they will fail automatically.