### PR TITLE
Replace Rake's testtask with Minitest's

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem "rake"
-gem "minitest"
+gem "minitest", "~> 5.16"
 gem "minitest-focus"
 gem "minitest-proveit"
 gem "minitest-reporters"

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-require 'rake/testtask'
+require "minitest/test_task"
 
-task :default => :test
+Minitest::TestTask.create
 
-Rake::TestTask.new do |t|
-  t.test_files = Dir.glob('test/lib/**/test_*.rb')
-  t.libs << "test"
-  t.warning = true
-end
+task default: :test


### PR DESCRIPTION
This is available since Minitest v5.16.0 and the following commit:

https://github.com/minitest/minitest/commit/73692f9202fbe8dcfe3069708beff155cdffa9bc