### PR TITLE
Clarify debug.rb compatibility in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1293,7 +1293,7 @@ The test suite passes on Windows with codepage `Windows-1252` if all the involve
 
 Zeitwerk works fine with [debug.rb](https://github.com/ruby/debug) and [Break](https://github.com/gsamokovarov/break).
 
-[Byebug](https://github.com/deivid-rodriguez/byebug) is compatible except for an edge case explained in [deivid-rodriguez/byebug#564](https://github.com/deivid-rodriguez/byebug/issues/564).
+[Byebug](https://github.com/deivid-rodriguez/byebug) is compatible except for an edge case explained in [deivid-rodriguez/byebug#564](https://github.com/deivid-rodriguez/byebug/issues/564). Prior to CRuby 3.1, debug.rb has a similar edge incompatibility.
 
 <a id="markdown-pronunciation" name="pronunciation"></a>
 ## Pronunciation


### PR DESCRIPTION
Hello!
I noticed I was running into the issue with byebug and zeitwerk mentioned in the README and in [this byebug issue](https://github.com/deivid-rodriguez/byebug/issues/564). I tried switching to debug.rb but had the same issue, which confused me since the docs mention it's compatible. As far as I can tell from the various GH issues, the debug.rb incompatibility was fixed in Ruby 3.1 onwards with a new TracePoint method mentioned in [this debug.rb PR](https://github.com/ruby/debug/pull/558). I'm running Ruby 2.7.7 so I tried Break instead, which worked!

I was hoping to get this mentioned in the README since it wasn't very clear to me what the problem was with debug.rb until I spent a bit of time trawling through a couple of GH issues.