### PR TITLE
Bump actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           - "head"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - uses: "ruby/setup-ruby@v1"
         with:
           ruby-version: ${{ matrix.ruby-version }}

--- a/.github/workflows/keep-an-eye-on-ruby-head.yml
+++ b/.github/workflows/keep-an-eye-on-ruby-head.yml
@@ -16,7 +16,7 @@ jobs:
           - "head"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - uses: "ruby/setup-ruby@v1"
         with:
           ruby-version: ${{ matrix.ruby-version }}


### PR DESCRIPTION
GitHub is [planning to upgrade to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). Versions prior to actions/checkout v3 use an outdated version of node, so we will upgrade to actions/checkout v4, where [Node 20 is the default](https://github.com/actions/checkout/releases/tag/v4.0.0).