### PR TITLE
Be more specific in NameError message

### DIFF
--- a/lib/zeitwerk/loader/callbacks.rb
+++ b/lib/zeitwerk/loader/callbacks.rb
@@ -18,7 +18,7 @@ module Zeitwerk::Loader::Callbacks
       to_unload[cpath] = [file, cref] if reloading_enabled?
       run_on_load_callbacks(cpath, cget(*cref), file) unless on_load_callbacks.empty?
     else
-      msg = "expected file #{file} to define constant #{cpath}, but didn't"
+      msg = "expected file #{file} to define constant ::#{cpath}, but didn't"
       log(msg) if logger
 
       # Ruby still keeps the autoload defined, but we remove it because the

--- a/test/lib/zeitwerk/test_exceptions.rb
+++ b/test/lib/zeitwerk/test_exceptions.rb
@@ -19,7 +19,7 @@ class TestExceptions < LoaderTest
     with_setup(files) do
       typo_rb = File.expand_path("typo.rb")
       error = assert_raises(Zeitwerk::NameError) { Typo }
-      assert_error_message "expected file #{typo_rb} to define constant Typo, but didn't", error
+      assert_error_message "expected file #{typo_rb} to define constant ::Typo, but didn't", error
       assert_equal :Typo, error.name
     end
   end
@@ -29,7 +29,7 @@ class TestExceptions < LoaderTest
     with_setup(files) do
       x_rb = File.expand_path("x.rb")
       error = assert_raises(Zeitwerk::NameError) { loader.eager_load }
-      assert_error_message "expected file #{x_rb} to define constant X, but didn't", error
+      assert_error_message "expected file #{x_rb} to define constant ::X, but didn't", error
       assert_equal :X, error.name
     end
   end
@@ -44,7 +44,7 @@ class TestExceptions < LoaderTest
     with_setup(files) do
       cli_x_rb = File.expand_path("cli/x.rb")
       error = assert_raises(Zeitwerk::NameError) { loader.eager_load }
-      assert_error_message "expected file #{cli_x_rb} to define constant Cli::X, but didn't", error
+      assert_error_message "expected file #{cli_x_rb} to define constant ::Cli::X, but didn't", error
       assert_equal :X, error.name
     end
   end

--- a/test/lib/zeitwerk/test_logging.rb
+++ b/test/lib/zeitwerk/test_logging.rb
@@ -136,7 +136,7 @@ class TestLogging < LoaderTest
   test "logs failed autoloads, provided the require call succeeded" do
     files = [["x.rb", ""]]
     with_files(files) do
-      assert_logged(/expected file #{File.expand_path("x.rb")} to define constant X, but didn't/) do
+      assert_logged(/expected file #{File.expand_path("x.rb")} to define constant ::X, but didn't/) do
         loader.push_dir(".")
         loader.setup
         assert_raises(Zeitwerk::NameError) { X }


### PR DESCRIPTION
Before: "expected file #{x_rb} to define constant X, but didn't"
After: "expected file #{x_rb} to define constant ::X, but didn't"

As far as I understand we're always looking for a top level constant.

I've repeatedly seen people be confused about this error message and I hope this small change can make it a little clearer.

Consider a file `app/models/register.rb` that defines `Registration::Register`. The _current_ error message would say that it expects the file to define `Register`, which it kind of does... within the `Registration` namespace. Better be explicit and say that we expect it to define `::Register`.

(Alternatively we could say "expected file X to define constant Register _at the top level_")

### Question
Should I add explicit test cases for [implicit namespaces](https://github.com/fxn/zeitwerk#implicit-namespaces) and/or [collapsed directories](https://github.com/fxn/zeitwerk#collapsing-directories)?