### PR TITLE
Make _abspath argument optional at the camelize method

### DIFF
--- a/lib/zeitwerk/inflector.rb
+++ b/lib/zeitwerk/inflector.rb
@@ -11,8 +11,8 @@ module Zeitwerk
     #
     # Takes into account hard-coded mappings configured with `inflect`.
     #
-    # @sig (String, String) -> String
-    def camelize(basename, _abspath)
+    # @sig (String, String?) -> String
+    def camelize(basename, _abspath = nil)
       overrides[basename] || basename.split('_').each(&:capitalize!).join
     end
 

--- a/lib/zeitwerk/null_inflector.rb
+++ b/lib/zeitwerk/null_inflector.rb
@@ -1,5 +1,13 @@
 class Zeitwerk::NullInflector
-  def camelize(basename, _abspath)
+  # Experimental inflector that does not change anything.
+  #
+  # inflector = Zeitwerk::NullInflector.new
+  # inflector.camelize("post", ...)             # => "post"
+  # inflector.camelize("UsersController", ...)  # => "UsersController"
+  # inflector.camelize("api", ...)              # => "api"
+  #
+  # @sig (String, String?) -> String
+  def camelize(basename, _abspath = nil)
     basename
   end
 end

--- a/test/lib/test_inflector.rb
+++ b/test/lib/test_inflector.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class TestInflector < Minitest::Test
   def camelize(str)
-    Zeitwerk::Inflector.new.camelize(str, nil)
+    Zeitwerk::Inflector.new.camelize(str)
   end
 
   test "capitalizes the first letter" do

--- a/test/lib/test_null_inflector.rb
+++ b/test/lib/test_null_inflector.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class TestNullInflector < Minitest::Test
   def camelize(str)
-    Zeitwerk::NullInflector.new.camelize(str, nil)
+    Zeitwerk::NullInflector.new.camelize(str)
   end
 
   test "does not change the basename" do


### PR DESCRIPTION
I noticed that the second argument for the `camelize` method was required, even when not using an absolute path.
Therefore, I suggest making the second parameter of camelize completely optional.


Before

```ruby
(rdbg) str
"users_controller"
(ruby) Zeitwerk::Inflector.new.camelize(str)
eval error: wrong number of arguments (given 1, expected 2)
  /home/ombu/code/ombu/oss/zeitwerk/lib/zeitwerk/inflector.rb:15:in `camelize'
  (rdbg)//home/ombu/code/ombu/oss/zeitwerk/test/lib/test_inflector.rb:1:in `camelize'
nil
(ruby) Zeitwerk::Inflector.new.camelize(str, nil)
"UsersController"
(ruby) Zeitwerk::Inflector.new.camelize(str, "random")
"UsersController"
```

After

```ruby
(rdbg) str
"point_3d_value"
(ruby) Zeitwerk::Inflector.new.camelize(str)
"Point3dValue"
(ruby) Zeitwerk::Inflector.new.camelize(str, nil)
"Point3dValue"
(ruby) Zeitwerk::Inflector.new.camelize(str, "random")
"Point3dValue"
```
Please, let me know if I have to add a record in the CHANGELOG


BTW, [I found rbs project interesting](https://github.com/ruby/rbs/blob/master/docs/syntax.md#optional-type)

Thanks for the gem!
