### PR TITLE
Prefer `Object.equal?` over unknown module `equal?` method

### DIFF
--- a/lib/zeitwerk/explicit_namespace.rb
+++ b/lib/zeitwerk/explicit_namespace.rb
@@ -29,7 +29,7 @@ module Zeitwerk
 
       # @sig (String) -> Zeitwerk::Loader?
       internal def loader_for(mod, cname)
-        cpath = mod.equal?(Object) ? cname.name : "#{real_mod_name(mod)}::#{cname}"
+        cpath = Object.equal?(mod) ? cname.name : "#{real_mod_name(mod)}::#{cname}"
         @cpaths.delete(cpath)
       end
 


### PR DESCRIPTION
This is totally nitpicky, but it's easier to assume `Object.equal?` is pristine, while for a random user defined module, it could have been changed.