### PR TITLE
Micro-optimization for explicit namespaces

### DIFF
--- a/lib/zeitwerk/cref.rb
+++ b/lib/zeitwerk/cref.rb
@@ -13,6 +13,9 @@
 class Zeitwerk::Cref
   include Zeitwerk::RealModName
 
+  # @sig Module
+  attr_reader :mod
+
   # @sig Symbol
   attr_reader :cname
 

--- a/lib/zeitwerk/explicit_namespace.rb
+++ b/lib/zeitwerk/explicit_namespace.rb
@@ -8,48 +8,56 @@ module Zeitwerk
   # Loaders that reopen namespaces owned by other projects are responsible for
   # loading their constant before setup. This is documented.
   module ExplicitNamespace # :nodoc: all
-    # Maps cpaths of explicit namespaces with their corresponding loader.
-    # Entries are added as the namespaces are found, and removed as they are
-    # autoloaded.
+    # Maps cnames or cpaths of explicit namespaces with their corresponding
+    # loader. They are symbols if the namespace lives in Object, or qualified
+    # paths as strings otherwise. Entries are added as the namespaces are found,
+    # and removed as they are autoloaded.
     #
-    # @sig Hash[String => Zeitwerk::Loader]
-    @cpaths = {}
+    # @sig Hash[(Symbol | String) => Zeitwerk::Loader]
+    @loaders = {}
 
     class << self
       include RealModName
       extend Internal
 
-      # Registers `cpath` as being the constant path of an explicit namespace
+      # Registers `cref` as being the constant path of an explicit namespace
       # managed by `loader`.
       #
       # @sig (String, Zeitwerk::Loader) -> void
-      internal def register(cpath, loader)
-        @cpaths[cpath] = loader
+      internal def register(cref, loader)
+        if Object.equal?(cref.mod)
+          @loaders[cref.cname] = loader
+        else
+          @loaders[cref.path] = loader
+        end
       end
 
       # @sig (String) -> Zeitwerk::Loader?
       internal def loader_for(mod, cname)
-        cpath = Object.equal?(mod) ? cname.name : "#{real_mod_name(mod)}::#{cname}"
-        @cpaths.delete(cpath)
+        if Object.equal?(mod)
+          @loaders.delete(cname)
+        else
+          @loaders.delete("#{real_mod_name(mod)}::#{cname}")
+        end
       end
 
       # @sig (Zeitwerk::Loader) -> void
       internal def unregister_loader(loader)
-        @cpaths.delete_if { _2.equal?(loader) }
+        @loaders.delete_if { _2.equal?(loader) }
       end
 
       # This is an internal method only used by the test suite.
       #
       # @sig (String) -> Zeitwerk::Loader?
-      internal def registered?(cpath)
-        @cpaths[cpath]
+      internal def registered?(cname_or_cpath)
+        @loaders[cname_or_cpath]
       end
 
       # This is an internal method only used by the test suite.
       #
       # @sig () -> void
       internal def clear
-        @cpaths.clear
+        @loaders.clear
       end
 
       module Synchronized

--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -553,7 +553,7 @@ module Zeitwerk
 
     # @sig (Zeitwerk::Cref) -> void
     private def register_explicit_namespace(cref)
-      ExplicitNamespace.__register(cref.path, self)
+      ExplicitNamespace.__register(cref, self)
     end
 
     # @sig (String) -> void

--- a/test/lib/zeitwerk/test_autovivification.rb
+++ b/test/lib/zeitwerk/test_autovivification.rb
@@ -63,7 +63,7 @@ class TestAutovivification < LoaderTest
       ["rd2/admin/y.rb", "Admin::Y = true"]
     ]
     with_setup(files) do
-      assert !Zeitwerk::ExplicitNamespace.__registered?("Admin")
+      assert !Zeitwerk::ExplicitNamespace.__registered?(:Admin)
     end
   end
 

--- a/test/lib/zeitwerk/test_unload.rb
+++ b/test/lib/zeitwerk/test_unload.rb
@@ -131,14 +131,14 @@ class TestUnload < LoaderTest
     ]
     with_files(files) do
       la = new_loader(dirs: "a")
-      assert Zeitwerk::ExplicitNamespace.__registered?("M") == la
+      assert Zeitwerk::ExplicitNamespace.__registered?(:M) == la
 
       lb = new_loader(dirs: "b")
-      assert Zeitwerk::ExplicitNamespace.__registered?("X") == lb
+      assert Zeitwerk::ExplicitNamespace.__registered?(:X) == lb
 
       la.unload
-      assert_nil Zeitwerk::ExplicitNamespace.__registered?("M")
-      assert Zeitwerk::ExplicitNamespace.__registered?("X") == lb
+      assert_nil Zeitwerk::ExplicitNamespace.__registered?(:M)
+      assert Zeitwerk::ExplicitNamespace.__registered?(:X) == lb
     end
   end
 

--- a/test/lib/zeitwerk/test_unregister.rb
+++ b/test/lib/zeitwerk/test_unregister.rb
@@ -10,7 +10,7 @@ class TestUnregister < LoaderTest
     registry.gem_loaders_by_root_file["dummy1"] = loader1
     registry.register_autoload(loader1, "dummy1")
     registry.register_inception("dummy1", "dummy1", loader1)
-    Zeitwerk::ExplicitNamespace.__register("dummy1", loader1)
+    Zeitwerk::ExplicitNamespace.__register(Zeitwerk::Cref.new(Object, :"dummy"), loader1)
 
     loader2 = Zeitwerk::Loader.new
     registry = Zeitwerk::Registry
@@ -18,7 +18,7 @@ class TestUnregister < LoaderTest
     registry.gem_loaders_by_root_file["dummy2"] = loader2
     registry.register_autoload(loader2, "dummy2")
     registry.register_inception("dummy2", "dummy2", loader2)
-    Zeitwerk::ExplicitNamespace.__register("dummy2", loader2)
+    Zeitwerk::ExplicitNamespace.__register(Zeitwerk::Cref.new(Object, :"dummy2"), loader2)
 
     loader1.unregister
 
@@ -26,13 +26,13 @@ class TestUnregister < LoaderTest
     assert !registry.gem_loaders_by_root_file.values.include?(loader1)
     assert !registry.autoloads.values.include?(loader1)
     assert !registry.inceptions.values.any? {|_, l| l == loader1}
-    assert !Zeitwerk::ExplicitNamespace.__registered?("dummy1")
+    assert !Zeitwerk::ExplicitNamespace.__registered?(:"dummy1")
 
     assert registry.loaders.include?(loader2)
     assert registry.gem_loaders_by_root_file.values.include?(loader2)
     assert registry.autoloads.values.include?(loader2)
     assert registry.inceptions.values.any? {|_, l| l == loader2}
-    assert Zeitwerk::ExplicitNamespace.__registered?("dummy2") == loader2
+    assert Zeitwerk::ExplicitNamespace.__registered?(:"dummy2") == loader2
   end
 
   test 'with_loader yields and unregisters' do


### PR DESCRIPTION
Explicit namespaces have an internal hash that maps the cpaths of known explicit namespaces to be loaded to the loader that manages them.

Every added constant needs to verify if there is a loader for the given pair (mod, cname), and that runs for all constants added, globally. So it is a hot spot worth of micro-optimizations.

In particular, for top-level constants (which are common and go through that callback during boot) nowadays we invoke `Symbol#name` and then perform a string lookup. Technically, we can save `Symbol#name` and have a symbol lookup instead, which is faster.

Registering performs an additional comparison now, but registering is more rare than const added.

The hypothesis would be that this may speed boot time up a little bit, and that eager loading would be more or less the same.

This complicates the code a bit, and the hash has mixed keys, which is rare. It would be worthwhile if we see a measurable improvement, otherwise the simpler version would stay.

@byroot what do you think?