### PR TITLE
Speedup the CI on Windows by skipping the toolchain as it's not needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+          # This CI job does not compile extensions so no need to install a toolchain (which takes 1+ min)
+          windows-toolchain: none
       - name: "Enable global frozen string literals for head"
         if: matrix.ruby-version == 'head'
         run: "echo RUBYOPT=--enable-frozen-string-literal >> $GITHUB_ENV"


### PR DESCRIPTION
Compare [before](https://github.com/fxn/zeitwerk/actions/runs/11299692884/usage) and [after](https://github.com/eregon/zeitwerk/actions/runs/11305055840/usage)