### PR TITLE
Manually defining inception namespaces to skip `autoload?` call

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,16 @@ Both strings and `Pathname` objects are supported as arguments. The method raise
 If you want to eager load a directory, `Zeitwerk::Loader#eager_load_dir` is more efficient than invoking `Zeitwerk::Loader#load_file` on its files.
 
 <a id="markdown-reloading" name="reloading"></a>
+
+#### Optimize performance by manually defining inceptions
+
+In order to avoid the costly `autoload?` call on all the autoloaded definitions you can manually define a list of namespaces to be included as inceptions.
+Use this as your own risk, note that after manually setting `manual_incepted_namespaces`, if you add a Gem which needs the inception you will need to include it in this list manually in order to have it working.
+
+```ruby
+loader.manual_incepted_namespaces = ['ActionCable']
+```
+
 ### Reloading
 
 <a id="markdown-configuration-and-usage" name="configuration-and-usage"></a>

--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -536,9 +536,20 @@ module Zeitwerk
       autoloads[abspath] = cref
       Registry.register_autoload(self, abspath)
 
-      # See why in the documentation of Zeitwerk::Registry.inceptions.
-      unless cref.autoload?
-        Registry.register_inception(cref.path, abspath, self)
+      # If manual incepted namespaces are present we skip the default behavior
+      # and we will only incept the manually defined namespaces for improved
+      # performance
+      if manual_incepted_namespaces.any?
+        if manual_incepted_namespaces.include?(cref.cname.name)
+          Registry.register_inception(cref.path, abspath, self)
+        end
+      else
+        # This operation can impact performance in big codebases since it will
+        # be evaluated for every single auoloaded constant.
+        # See why in the documentation of Zeitwerk::Registry.inceptions.
+        unless cref.autoload?
+          Registry.register_inception(cref.path, abspath, self)
+        end
       end
     end
 

--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -539,15 +539,15 @@ module Zeitwerk
       # If manual incepted namespaces are present we skip the default behavior
       # and we will only incept the manually defined namespaces for improved
       # performance
-      if manual_incepted_namespaces.any?
-        if manual_incepted_namespaces.include?(cref.cname.name)
-          Registry.register_inception(cref.path, abspath, self)
-        end
-      else
+      if manual_incepted_namespaces.empty?
         # This operation can impact performance in big codebases since it will
         # be evaluated for every single auoloaded constant.
         # See why in the documentation of Zeitwerk::Registry.inceptions.
         unless cref.autoload?
+          Registry.register_inception(cref.path, abspath, self)
+        end
+      else
+        if manual_incepted_namespaces.include?(cref.cname.name)
           Registry.register_inception(cref.path, abspath, self)
         end
       end

--- a/lib/zeitwerk/loader/config.rb
+++ b/lib/zeitwerk/loader/config.rb
@@ -13,6 +13,9 @@ module Zeitwerk::Loader::Config
   # @sig #call | #debug | nil
   attr_accessor :logger
 
+  # @sig nil
+  attr_accessor :manual_incepted_namespaces
+
   # Absolute paths of the root directories, mapped to their respective root namespaces:
   #
   #   "/Users/fxn/blog/app/channels" => Object,
@@ -84,20 +87,21 @@ module Zeitwerk::Loader::Config
   private :on_unload_callbacks
 
   def initialize
-    @inflector              = Zeitwerk::Inflector.new
-    @logger                 = self.class.default_logger
-    @tag                    = SecureRandom.hex(3)
-    @initialized_at         = Time.now
-    @roots                  = {}
-    @ignored_glob_patterns  = Set.new
-    @ignored_paths          = Set.new
-    @collapse_glob_patterns = Set.new
-    @collapse_dirs          = Set.new
-    @eager_load_exclusions  = Set.new
-    @reloading_enabled      = false
-    @on_setup_callbacks     = []
-    @on_load_callbacks      = {}
-    @on_unload_callbacks    = {}
+    @inflector                  = Zeitwerk::Inflector.new
+    @logger                     = self.class.default_logger
+    @manual_incepted_namespaces = []
+    @tag                        = SecureRandom.hex(3)
+    @initialized_at             = Time.now
+    @roots                      = {}
+    @ignored_glob_patterns      = Set.new
+    @ignored_paths              = Set.new
+    @collapse_glob_patterns     = Set.new
+    @collapse_dirs              = Set.new
+    @eager_load_exclusions      = Set.new
+    @reloading_enabled          = false
+    @on_setup_callbacks         = []
+    @on_load_callbacks          = {}
+    @on_unload_callbacks        = {}
   end
 
   # Pushes `path` to the list of root directories.

--- a/lib/zeitwerk/loader/config.rb
+++ b/lib/zeitwerk/loader/config.rb
@@ -13,7 +13,7 @@ module Zeitwerk::Loader::Config
   # @sig #call | #debug | nil
   attr_accessor :logger
 
-  # @sig nil
+  # @sig Set[String]
   attr_accessor :manual_incepted_namespaces
 
   # Absolute paths of the root directories, mapped to their respective root namespaces:
@@ -89,7 +89,7 @@ module Zeitwerk::Loader::Config
   def initialize
     @inflector                  = Zeitwerk::Inflector.new
     @logger                     = self.class.default_logger
-    @manual_incepted_namespaces = []
+    @manual_incepted_namespaces = Set.new
     @tag                        = SecureRandom.hex(3)
     @initialized_at             = Time.now
     @roots                      = {}


### PR DESCRIPTION
In our journey of improving our Rails application bootstrap we have detected that calling the method `Module.autoload?` for each `autoload` registration is very costly.
In our case it takes >3s. (see attached flamegraphs)

![image](https://github.com/user-attachments/assets/0f969d78-9302-4876-82b7-1ae8123a08aa)


As the comment in the implementation points out, this call is there to support an edge case on how certain gems autoload themselves. [More info here](https://github.com/fxn/zeitwerk/blob/main/lib/zeitwerk/registry.rb#L28) However this approach produces [a call](https://github.com/fxn/zeitwerk/blob/main/lib/zeitwerk/loader.rb#L540) to `Module.autoload?` for every single constant in our huge project. As it can be seen in the attached flamegraph. This is taking for our backend more than 3 seconds just to support few gems with this special case.

In this PR we propose to enable a mechanism on which any Rails application can manually define the namespaces to be incepted and avoid the costly call for the rest of the constants. This resulted in a boot reduction of more than 3 seconds in our case. We only had to define 3 namespaces to be incepted in order to make our backend run properly.

This is the resulting flamegraph:

![image](https://github.com/user-attachments/assets/70f0c358-bad7-44f4-b345-a6a399855275)


As a trade-off I understand that this will cause confusion to developers including gems needing the inception. So this PR proposes to keep backwards compatibility if you don't manually set `manual_incepted_namespaces`.

TODO:
- [ ] Add meaningful tests