### PR TITLE
Add TruffleRuby stable to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,14 @@ jobs:
         ruby-version:
           - "3.2"
           - "3.3"
-          - "truffleruby-head"
+          - "truffleruby"
           - "head"
+          - "truffleruby-head"
         exclude:
-          - { os: "windows-latest", ruby-version: "truffleruby-head" }
-
+          - os: windows-latest
+            ruby-version: truffleruby
+          - os: windows-latest
+            ruby-version: truffleruby-head
     runs-on: ${{ matrix.os }}
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/keep-an-eye-on-ruby-head.yml
+++ b/.github/workflows/keep-an-eye-on-ruby-head.yml
@@ -14,6 +14,7 @@ jobs:
           - "windows-latest"
         ruby-version:
           - "head"
+          - "truffleruby-head"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: "actions/checkout@v4"


### PR DESCRIPTION
After addressing https://github.com/oracle/truffleruby/issues/3683, we can start testing against `truffleruby`, and keep an eye on `truffleruby-head` too.