### PR TITLE
Update links from master to main

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -199,7 +199,7 @@ module Zeitwerk
           # To make it aware of changes, the gem defines singleton methods in
           # $LOADED_FEATURES:
           #
-          #   https://github.com/Shopify/bootsnap/blob/master/lib/bootsnap/load_path_cache/core_ext/loaded_features.rb
+          #   https://github.com/Shopify/bootsnap/blob/main/lib/bootsnap/load_path_cache/core_ext/loaded_features.rb
           #
           # Rails applications may depend on bootsnap, so for unloading to work
           # in that setting it is preferable that we restrict our API choice to

--- a/zeitwerk.gemspec
+++ b/zeitwerk.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.version  = Zeitwerk::VERSION
   spec.metadata = {
     "homepage_uri"    => "https://github.com/fxn/zeitwerk",
-    "changelog_uri"   => "https://github.com/fxn/zeitwerk/blob/master/CHANGELOG.md",
+    "changelog_uri"   => "https://github.com/fxn/zeitwerk/blob/main/CHANGELOG.md",
     "source_code_uri" => "https://github.com/fxn/zeitwerk",
     "bug_tracker_uri" => "https://github.com/fxn/zeitwerk/issues"
   }


### PR DESCRIPTION
Reflects default branch changes from master to main where appropriate. Silences the "Branch master was renamed to main." banner on GitHub. Skips occurrences in CHANGELOG.md to avoid altering past entries.