### PR TITLE
Use Array#pop instead of Array#shift

### DIFF
--- a/lib/zeitwerk/loader/helpers.rb
+++ b/lib/zeitwerk/loader/helpers.rb
@@ -56,7 +56,7 @@ module Zeitwerk::Loader::Helpers
   private def has_at_least_one_ruby_file?(dir)
     to_visit = [dir]
 
-    while (dir = to_visit.shift)
+    while (dir = to_visit.pop)
       Dir.each_child(dir) do |basename|
         next if hidden?(basename)
 


### PR DESCRIPTION
This is a super-micro-optimization but figured might be worth it to put up a PR. `Array#shift` is `O(n)` while `Array#pop` is `O(1)`. We have some deeply nested directories and this seems to help a little bit. This does change the order of the search...but I don't think that matters here.