### PR TITLE
Track visited directories when scanning for Ruby files

### DIFF
--- a/lib/zeitwerk/loader/file_system.rb
+++ b/lib/zeitwerk/loader/file_system.rb
@@ -77,8 +77,14 @@ class Zeitwerk::Loader::FileSystem # :nodoc:
   #: (String) -> bool
   def has_at_least_one_ruby_file?(dir)
     to_visit = [dir]
+    visited = {} #: Hash[[Integer, Integer], true]
 
     while (dir = to_visit.shift)
+      stat = File.stat(dir)
+      key = [stat.dev, stat.ino]
+      next if visited[key]
+      visited[key] = true
+
       relevant_dir_entries(dir) do |_, abspath, ftype|
         return true if :file == ftype
         to_visit << abspath


### PR DESCRIPTION
This PR prevents non-terminating breadth-first traversal in cyclic directory graphs and adds a regression test for cycles.

I’ve been amazed at Codex’ ability to find real bugs — it recently found several subtle security issues in Phlex. Anyway, I thought I would give it the *ultimate* test (and I mean this as a compliment) and see if it could find anything in Zeitwerk. This is the only thing it found.

I was able to reproduce the issue manually by creating a looping directory structure with a symlink in one of my projects that uses Zeitwerk. However, I found my operating system seems to stop this loop after about 32 iterations, which effectively prevents any issues from surfacing anyway.

I’m not sure if all operating systems do this or if you would even consider this a bug given that it’s already prevented by a different layer but I thought you might want to know about it anyway.

❤️