### PR TITLE
Make qualified constant paths work with #on_load

### DIFF
--- a/lib/zeitwerk/loader/config.rb
+++ b/lib/zeitwerk/loader/config.rb
@@ -278,7 +278,13 @@ module Zeitwerk::Loader::Config
   #
   #: (String?) { (top, String) -> void } -> void ! TypeError
   def on_load(cpath = :ANY, &block)
-    raise TypeError, 'on_load only accepts strings' unless cpath.is_a?(String) || cpath == :ANY
+    case cpath
+    when String
+      cpath = cpath.delete_prefix("::")
+    when :ANY
+    else
+      raise TypeError, 'on_load only accepts strings'
+    end
 
     mutex.synchronize do
       (on_load_callbacks[cpath] ||= []) << block

--- a/test/lib/zeitwerk/test_on_load.rb
+++ b/test/lib/zeitwerk/test_on_load.rb
@@ -202,4 +202,15 @@ class TestOnLoad < LoaderTest
       assert loaded
     end
   end
+
+  test 'on_load with qualified cpath executes callback' do
+    files = [['a/b.rb', 'class A::B; end']]
+    with_setup(files) do
+      loaded = false
+      loader.on_load('::A::B') { loaded = A::B }
+
+      assert A::B
+      assert loaded
+    end
+  end
 end


### PR DESCRIPTION
Qualified constant names (`"::A::B"` vs `"A::B"`) should work with Zeitwerk `on_load` callbacks, but right now they currently silently fail. This patch trims prefixed scope operators `::` so that the constant name may be understood by Zeitwerk.

Related to https://github.com/rails/rails/pull/57379, this bug was discovered while implementing an API for class level load hooks in Rails. I'm open to issuing a warning, raising an error, or something else instead. I think the main point here is that we should not silently register these callbacks and never end up calling them. I was curious if you could have a constant in Ruby that starts with `:`, and it seems like you cannot:

```
irb(main):001> class A; end
=> nil
irb(main):002> Object.const_get("::A")
=> A
irb(main):003> Object.const_set("::B", Module.new)
(irb):4:in 'Module#const_set': wrong constant name ::B (NameError)
        from (irb):4:in '<main>'
        ...
irb(main):004> RUBY_VERSION
=> "4.0.1"
```