### PR TITLE
Enable Style/FrozenStringLiteralComment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ Layout/EndAlignment:
 
 Style/StringLiterals:
   EnforcedStyle: single_quotes
+
+Style/FrozenStringLiteralComment:
+  Enabled: true

--- a/lib/zeitwerk/loader/constant_path_validator.rb
+++ b/lib/zeitwerk/loader/constant_path_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # @private
 class Zeitwerk::Loader::ConstantPathValidator # :nodoc
   CNAME_VALIDATOR = Module.new.freeze #: Module

--- a/lib/zeitwerk/loader/eager_load.rb
+++ b/lib/zeitwerk/loader/eager_load.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Zeitwerk::Loader::EagerLoad
   # Eager loads all files in the root directories, recursively. Files do not
   # need to be in `$LOAD_PATH`, absolute file names are used.

--- a/lib/zeitwerk/null_inflector.rb
+++ b/lib/zeitwerk/null_inflector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Zeitwerk::NullInflector
   #: (String, String) -> String
   def camelize(basename, _abspath)

--- a/lib/zeitwerk/registry/autoloads.rb
+++ b/lib/zeitwerk/registry/autoloads.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Zeitwerk::Registry
   class Autoloads # :nodoc:
     #: () -> void

--- a/lib/zeitwerk/registry/inceptions.rb
+++ b/lib/zeitwerk/registry/inceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Zeitwerk::Registry
   # Loaders know their own inceptions, but there is a use case in which we need
   # to know if a given cpath is an inception globally. This is what this

--- a/lib/zeitwerk/registry/loaders.rb
+++ b/lib/zeitwerk/registry/loaders.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Zeitwerk::Registry
   class Loaders # :nodoc:
     #: () -> void

--- a/test/lib/zeitwerk/test_eager_load_namespace.rb
+++ b/test/lib/zeitwerk/test_eager_load_namespace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestEagerLoadNamespaceWithObjectRootNamespace < LoaderTest

--- a/test/lib/zeitwerk/test_load_file.rb
+++ b/test/lib/zeitwerk/test_load_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'test_helper'
 


### PR DESCRIPTION
ConstantPathValidator and EagerLoad both currently allocate "::" repeatedly (many thousands of times when eager loading my app).

This commit removes those allocations by enabling frozen_string_literal (using RuboCop so that any new files aren't missed in the future).