### PR TITLE
Raise a controlled error for non-module namespaces

### DIFF
--- a/lib/zeitwerk/loader.rb
+++ b/lib/zeitwerk/loader.rb
@@ -573,8 +573,12 @@ module Zeitwerk
       else
         # For whatever reason the constant that corresponds to this namespace has
         # already been defined, we have to recurse.
+        namespace = cref.get
+        unless namespace.is_a?(Module)
+          raise Zeitwerk::Error, "#{cref} is expected to be a namespace, should be a class or module (got #{namespace.class})"
+        end
         log { "the namespace #{cref} already exists, descending into #{subdir}" }
-        define_autoloads_for_dir(subdir, cref.get, external:)
+        define_autoloads_for_dir(subdir, namespace, external:)
       end
     end
 

--- a/test/lib/zeitwerk/test_autovivification.rb
+++ b/test/lib/zeitwerk/test_autovivification.rb
@@ -69,15 +69,14 @@ class TestAutovivification < LoaderTest
   end
 
   test 'raises a controlled error if an existing namespace is not a class or module' do
-    Namespace.const_set(:Admin, 1)
+    Namespace::Admin = 1
+    on_teardown { remove_const :Admin, from: Namespace }
     files = [['admin/x.rb', '']]
 
     error = assert_raises(Zeitwerk::Error) do
       with_setup(files, namespace: Namespace)
     end
     assert_equal "#{Namespace}::Admin is expected to be a namespace, should be a class or module (got Integer)", error.message
-  ensure
-    Namespace.__send__(:remove_const, :Admin)
   end
 
   test 'autovivification is synchronized' do

--- a/test/lib/zeitwerk/test_autovivification.rb
+++ b/test/lib/zeitwerk/test_autovivification.rb
@@ -68,6 +68,18 @@ class TestAutovivification < LoaderTest
     end
   end
 
+  test 'raises a controlled error if an existing namespace is not a class or module' do
+    Namespace.const_set(:Admin, 1)
+    files = [['admin/x.rb', '']]
+
+    error = assert_raises(Zeitwerk::Error) do
+      with_setup(files, namespace: Namespace)
+    end
+    assert_equal "#{Namespace}::Admin is expected to be a namespace, should be a class or module (got Integer)", error.message
+  ensure
+    Namespace.__send__(:remove_const, :Admin)
+  end
+
   test 'autovivification is synchronized' do
     $test_admin_const_set_calls = 0
     $test_admin_const_set_queue = Queue.new


### PR DESCRIPTION
When a managed subdirectory maps to an already-defined non-module constant, setup currently leaks `NoMethodError` from the recursive directory walk. Validate the existing value first and raise `Zeitwerk::Error` with the constant path and actual class, matching the controlled namespace-error contract used elsewhere.

Verified with an isolated reproduction on Ruby 4.0.6 and 3.2.11, the complete 528-test / 1,202-assertion suite on both Rubies, RuboCop (80 files), syntax checks and package builds.