### PR TITLE
Fix documentation typos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This is the repository for the Ruby gem Zeitwerk, which provides autoloading, ea
 ## Development tips
 
 - Read the README.md.
-- Study the current implemetation under the `lib` directory.
+- Study the current implementation under the `lib` directory.
 - Study the existing test suite under `test`.
 - Execute commands for Ruby tools with `mise exec -- <command>`.
 
@@ -17,6 +17,6 @@ This is the repository for the Ruby gem Zeitwerk, which provides autoloading, ea
 
 ## Testing tips
 
-- How to run the entire test suite: `mixe exec -- bin/test`.
+- How to run the entire test suite: `mise exec -- bin/test`.
 - How to run the tests in a certain file: `mise exec -- bin/test <file>`
 - How to run the test in a certain file and line: `mise exec -- bin/test <file>:<line>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,7 +259,7 @@
 * A message is logged if an autoload did not define the expected constant.
 
   When that happens, `Zeitwerk::NameError` is raised and you normally see the
-  exception. But if the error is shallowed, and you are inspecting the logs to
+  exception. But if the error is swallowed, and you are inspecting the logs to
   investigate something, this new message may be helpful.
 
 * By default, `Zeitwerk::Loader#dirs` filters ignored root directories out.
@@ -616,7 +616,7 @@ enforced with stricter formal visibility.
 
 ## 2.1.7 (29 June 2019)
 
-* Prevent the inflector from deleting parts un multiword constants whose capitalization is the same. For example, `point_2d` should be inflected as `Point2d`, rather than `Point`. While the inflector is frozen, this seems to be just wrong, and the refinement should be backwards compatible, since those constants were not usable.
+* Prevent the inflector from deleting parts in multiword constants whose capitalization is the same. For example, `point_2d` should be inflected as `Point2d`, rather than `Point`. While the inflector is frozen, this seems to be just wrong, and the refinement should be backwards compatible, since those constants were not usable.
 
 * Make eager loading consistent with auto loading with regard to detecting namespaces that do not define the matching constant.
 

--- a/README.md
+++ b/README.md
@@ -973,7 +973,7 @@ loader.on_load('SomeApiClient') do |klass, _abspath|
 end
 ```
 
-Some uses cases:
+Some use cases:
 
 * Doing something with a reloadable class or module in a Rails application during initialization, in a way that plays well with reloading. As in the previous example.
 * Delaying the execution of the block until the class is loaded for performance.
@@ -1364,7 +1364,7 @@ loader.cpath_expected_at('8.rb') # => Zeitwerk::NameError
 
 This method does not parse file contents and does not guarantee files define the returned constant path.
 
-Similarly, this method does not validate the project tree. If the project has conflicting oridinary and nsfiles for the same namespace, for example, the call will return the expected constant path for each of them without raising.
+Similarly, this method does not validate the project tree. If the project has conflicting ordinary files and nsfiles for the same namespace, for example, the call will return the expected constant path for each of them without raising.
 
 `Zeitwerk::Loader#cpath_expected_at` is designed to be used with individual paths. If you want to know all the expected constant paths in the project, please use `Zeitwerk::Loader#all_expected_cpaths`, documented next.
 
@@ -1414,7 +1414,7 @@ The order of the hash entries is undefined.
 
 This method does not parse file contents and does not guarantee files define the returned constant path.
 
-Similarly, this method does not validate the project tree. If the project has conflicting oridinary and nsfiles for the same namespace, for example, the call will return the expected constant path for each of them without raising.
+Similarly, this method does not validate the project tree. If the project has conflicting ordinary files and nsfiles for the same namespace, for example, the call will return the expected constant path for each of them without raising.
 
 <a id="markdown-encodings" name="encodings"></a>
 ### Encodings

--- a/lib/zeitwerk/loader/callbacks.rb
+++ b/lib/zeitwerk/loader/callbacks.rb
@@ -25,7 +25,7 @@ module Zeitwerk::Loader::Callbacks # :nodoc: all
 
       # Since the expected constant was not defined, there is nothing to unload.
       # However, if the exception is rescued and reloading is enabled, we still
-      # need to deleted the file from $LOADED_FEATURES.
+      # need to delete the file from $LOADED_FEATURES.
       to_unload[file] = cref if reloading_enabled?
 
       raise Zeitwerk::NameError.new(msg, cref.cname)


### PR DESCRIPTION
Correct eight small persistent typos in contributor instructions, README/changelog prose and one runtime comment. No behavior changes.

The complete 528-test / 1,202-assertion suite passes on Ruby 4.0.6 and 3.2.11, as does RuboCop over all 80 inspected files.