### PR TITLE
Pin CI actions and restrict workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,16 @@ on:
   pull_request:
     branches:
       - "main"
+
+permissions:
+  contents: read
+
 jobs:
   rubocop:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v4"
-      - uses: "ruby/setup-ruby@v1"
+      - uses: "actions/checkout@11d5960a326750d5838078e36cf38b85af677262" # v4.4.0
+      - uses: "ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b" # v1.321.0
         with:
           ruby-version: "3.2"
           bundler-cache: true
@@ -42,8 +46,8 @@ jobs:
             ruby-version: "4.0"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: "actions/checkout@v4"
-      - uses: "ruby/setup-ruby@v1"
+      - uses: "actions/checkout@11d5960a326750d5838078e36cf38b85af677262" # v4.4.0
+      - uses: "ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b" # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true

--- a/.github/workflows/keep-an-eye-on-ruby-head.yml
+++ b/.github/workflows/keep-an-eye-on-ruby-head.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "11 9 * * *"
+
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -16,8 +20,8 @@ jobs:
           - "head"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: "actions/checkout@v4"
-      - uses: "ruby/setup-ruby@v1"
+      - uses: "actions/checkout@11d5960a326750d5838078e36cf38b85af677262" # v4.4.0
+      - uses: "ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b" # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true

--- a/.github/workflows/keep-an-eye-on-truffleruby-head.yml
+++ b/.github/workflows/keep-an-eye-on-truffleruby-head.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "10 10 * * *"
+
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -15,8 +19,8 @@ jobs:
           - "truffleruby-head"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: "actions/checkout@v4"
-      - uses: "ruby/setup-ruby@v1"
+      - uses: "actions/checkout@11d5960a326750d5838078e36cf38b85af677262" # v4.4.0
+      - uses: "ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b" # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true


### PR DESCRIPTION
## Summary

Harden Zeitwerk's three GitHub Actions workflows by restricting their tokens to read-only repository contents and pinning third-party actions to immutable commits.

## Security impact (low urgency)

The workflows currently follow mutable action references and rely on GitHub's ambient default token permissions. A moved or compromised ref could therefore change code executed by CI without a reviewed Zeitwerk commit. This patch keeps the same action major versions while making the currently resolved releases immutable and minimizing token permissions.

There is no evidence that either action or reference has been compromised.

## Changes

- pin `actions/checkout` v4.4.0 to `11d5960a326750d5838078e36cf38b85af677262`
- pin `ruby/setup-ruby` v1.321.0 to `95ef2b042f9d7a56d8268cba8559e2842e2ad01b`
- declare `contents: read` in CI and both scheduled HEAD workflows

## Verification

- verified each commit against its upstream release tag/branch
- parsed all three workflow files with Ruby/Psych
- ran `bundle exec minitest`: 529 tests, 1,204 assertions, 0 failures
- ran `bundle exec rubocop`: 81 files, 0 offenses
- compiled all 25 runtime files and built the 27-file gem
- ran `git diff --check`

## Compatibility

No runtime or package behavior changes. No breaking changes.
